### PR TITLE
Fix Bad Request error when cancel Booking

### DIFF
--- a/front-end/src/api/bookingApi.js
+++ b/front-end/src/api/bookingApi.js
@@ -187,7 +187,7 @@ export async function cancelVenueBooking(bookingId, cancellationReason = "") {
     headers: getAuthHeaders(true),
     body: JSON.stringify({
       bookingId: bookingId,
-      cancellationReason: cancellationReason
+      reason: cancellationReason
     }),
   });
 
@@ -209,7 +209,7 @@ export async function cancelServiceBooking(bookingId, cancellationReason = "") {
     headers: getAuthHeaders(true),
     body: JSON.stringify({
       bookingId: bookingId,
-      cancellationReason: cancellationReason
+      reason: cancellationReason
     }),
   });
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/ServiceController.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/ServiceController.java
@@ -30,7 +30,7 @@ public class ServiceController {
 
     @Operation(summary = "Get all services", description = "Retrieves a paginated list of all services")
     @GetMapping(ServiceControllerConstants.GET_ALL_SERVICES_URL)
-    @PreAuthorize("hasAnyRole('" + ORGANIZER_ROLE + "', '" + VENUE_PROVIDER_ROLE + "','" + ADMIN_ROLE + "')")
+    @PreAuthorize("hasAnyRole('" + ORGANIZER_ROLE + "', '" + SERVICE_PROVIDER_ROLE + "','" + ADMIN_ROLE + "')")
     public Page<ServicesDTO> getAllServices(@ParameterObject @PageableDefault() Pageable pageable) {
         return servicesService.getAllServices(pageable);
     }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/EventBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/EventBookingService.java
@@ -3,6 +3,7 @@ package com.example.cdr.eventsmanagementsystem.Service.Booking;
 import java.time.LocalDateTime;
 
 import com.example.cdr.eventsmanagementsystem.Service.Payment.StripeService;
+import com.example.cdr.eventsmanagementsystem.Util.BookingUtil;
 import org.springframework.context.ApplicationEventPublisher;
 
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingType;
@@ -52,6 +53,7 @@ public class EventBookingService {
     private final StripeService stripeService;
     private final EventBookingMapper bookingMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final BookingUtil bookingUtil;
 
     public Page<EventBookingResponse> getAllEventBookings(Pageable pageable) {
         Page<EventBooking> bookings = bookingRepository.findAll(pageable);
@@ -168,7 +170,8 @@ public class EventBookingService {
         }
 
         if (booking.getStripePaymentId() != null && booking.getStatus() == BookingStatus.BOOKED) {
-            stripeService.createRefund(booking.getStripePaymentId(), null, "Customer requested cancellation");
+            String stripeReason = bookingUtil.mapToStripeRefundReason(request.getReason());
+            stripeService.createRefund(booking.getStripePaymentId(), null, stripeReason);
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/ServiceBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/ServiceBookingService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingType;
 
 import com.example.cdr.eventsmanagementsystem.Service.Payment.StripeService;
+import com.example.cdr.eventsmanagementsystem.Util.BookingUtil;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +54,7 @@ public class ServiceBookingService {
     private final StripeService stripeService;
     private final ServiceBookingMapper bookingMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final BookingUtil bookingUtil;
 
     public Page<ServiceBookingResponse> getAllServiceBookings(Pageable pageable) {
         Page<ServiceBooking> bookings = bookingRepository.findAll(pageable);
@@ -164,7 +166,8 @@ public class ServiceBookingService {
         }
 
         if (booking.getStripePaymentId() != null && booking.getStatus() == BookingStatus.BOOKED) {
-            stripeService.createRefund(booking.getStripePaymentId(), null, "Customer requested cancellation");
+            String stripeReason = bookingUtil.mapToStripeRefundReason(request.getReason());
+            stripeService.createRefund(booking.getStripePaymentId(), null, stripeReason);
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/VenueBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/VenueBookingService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import com.example.cdr.eventsmanagementsystem.Service.Payment.StripeService;
+import com.example.cdr.eventsmanagementsystem.Util.BookingUtil;
 import org.springframework.context.ApplicationEventPublisher;
 
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingType;
@@ -53,6 +54,7 @@ public class VenueBookingService {
     private final StripeService stripeService;
     private final VenueBookingMapper bookingMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final BookingUtil bookingUtil;
 
     public Page<VenueBookingResponse> getAllVenueBookings(Pageable pageable) {
         Page<VenueBooking> bookings = bookingRepository.findAll(pageable);
@@ -164,7 +166,8 @@ public class VenueBookingService {
         }
 
         if (booking.getStripePaymentId() != null && booking.getStatus() == BookingStatus.BOOKED) {
-            stripeService.createRefund(booking.getStripePaymentId(), null, "Customer requested cancellation");
+            String stripeReason = bookingUtil.mapToStripeRefundReason(request.getReason());
+            stripeService.createRefund(booking.getStripePaymentId(), null, stripeReason);
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Util/BookingUtil.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Util/BookingUtil.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -97,6 +99,15 @@ public class BookingUtil {
             case EVENT -> eventBookingRepository.findByStripePaymentId(paymentId);
             case VENUE -> venueBookingRepository.findByStripePaymentId(paymentId);
             case SERVICE -> serviceBookingRepository.findByStripePaymentId(paymentId);
+        };
+    }
+
+    public String mapToStripeRefundReason(String reason) {
+        return switch (reason.toLowerCase()) {
+            case "duplicate" -> "duplicate";
+            case "fraudulent" -> "fraudulent";
+            case "requested_by_customer", "customer requested cancellation" -> "requested_by_customer";
+            default -> "requested_by_customer"; // fallback for any other string
         };
     }
 }


### PR DESCRIPTION
What
Fix booking cancellation by mapping reasons to Stripe-accepted values, updating cancelBooking calls, and fixing role checks.

Why
Previously, canceling bookings failed due to invalid refund reasons and wrong authorization checks.

Changes
- Map cancellation reason before calling Stripe service
- Update cancelBooking API call in frontend
- Fix PreAuthorize role in getAllServices method