### PR TITLE
chore(frontend): dev hot-reload via compose.override.yml

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,22 @@
+services:
+  frontend:
+    build: null
+    image: node:20-alpine
+    working_dir: /app
+    command: sh -c "npm ci && npm start"
+    ports:
+      - "3000:3000"
+    environment:
+      - HOST=0.0.0.0
+      - CHOKIDAR_USEPOLLING=true
+      - WATCHPACK_POLLING=true
+      - REACT_APP_KEYCLOAK_BASE_URL=http://localhost:8080
+      - REACT_APP_KEYCLOAK_REALM=EMS-realm
+      - REACT_APP_KEYCLOAK_CLIENT_ID=ems-frontend
+      - REACT_APP_API_BASE=http://localhost:8180
+    volumes:
+      - ./front-end:/app
+      - /app/node_modules
+    depends_on:
+      - keycloak
+      - backend


### PR DESCRIPTION
Adds compose.override.yml to run the frontend as a Node dev server with hot reload.
- Eliminates the need for `docker compose up --build` on FE changes
- `build: null` prevents FE rebuilds; backend can still rebuild normally
- For prod, run with only compose.yml: `docker compose -f compose.yml up --build -d frontend`
-Commands to run it: 1) docker compose up -d postgres keycloak backend 
2) docker compose up frontend

