### PR TITLE
Support soft deletes for venues and services

### DIFF
--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Service/Services.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Service/Services.java
@@ -5,12 +5,16 @@ import com.example.cdr.eventsmanagementsystem.Util.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Data
 @EqualsAndHashCode(callSuper = true)
+@SQLDelete(sql = "UPDATE services SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @Table(name = "services")
 public class Services extends BaseEntity {
     @Column(nullable = false)
@@ -38,4 +42,7 @@ public class Services extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "service_provider_id", nullable = false)
     private ServiceProvider serviceProvider;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Service/Services.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Service/Services.java
@@ -44,5 +44,5 @@ public class Services extends BaseEntity {
     private ServiceProvider serviceProvider;
 
     @Column(nullable = false)
-    private boolean deleted = false;
+    private boolean deleted;
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Venue/Venue.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Venue/Venue.java
@@ -1,19 +1,20 @@
 package com.example.cdr.eventsmanagementsystem.Model.Venue;
 
-import com.example.cdr.eventsmanagementsystem.Model.Booking.VenueBooking;
 import com.example.cdr.eventsmanagementsystem.Model.Event.EventType;
 import com.example.cdr.eventsmanagementsystem.Model.User.VenueProvider;
 import com.example.cdr.eventsmanagementsystem.Util.BaseEntity;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Entity
 @Data
 @EqualsAndHashCode(callSuper = true)
+@SQLDelete(sql = "UPDATE venue SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @Table(name = "venue")
 public class Venue extends BaseEntity {
     @Column(nullable = false)
@@ -52,4 +53,7 @@ public class Venue extends BaseEntity {
     )
     @Enumerated(EnumType.STRING)
     private Set<EventType> supportedEventTypes = new HashSet<>();
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Venue/Venue.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Model/Venue/Venue.java
@@ -55,5 +55,5 @@ public class Venue extends BaseEntity {
     private Set<EventType> supportedEventTypes = new HashSet<>();
 
     @Column(nullable = false)
-    private boolean deleted = false;
+    private boolean deleted;
 }


### PR DESCRIPTION
Fixes #65 
Fixes #83 

- Added a `deleted` boolean field (default false) to Venue and Service.
- Updated delete operations to set `deleted = true` instead of physically removing the record.
- Added automatic filtering `@Where(clause = "deleted = false"`) so queries on venues and services ignore soft-deleted records.