### PR TITLE
Fix/issue 84

### DIFF
--- a/front-end/src/api/adminApi.js
+++ b/front-end/src/api/adminApi.js
@@ -330,3 +330,19 @@ export async function getDailyBookings(startISO, endISO) {
    }
    return await response.json();
  }
+
+
+export async function getDailyBookingsBreakdown(dateISO /* YYYY-MM-DD */) {
+  const url = buildApiUrl(`/v1/admin/daily-bookings-breakdown?date=${encodeURIComponent(dateISO)}`);
+  const res = await fetch(url, { headers: getAuthHeaders() });
+  if (!res.ok) throw new Error(`Failed to load bookings breakdown: ${res.status} ${res.statusText}`);
+  return res.json(); // { venue, services, events, total }
+}
+
+export async function getDailyCancellationsBreakdown(dateISO) {
+  const url = buildApiUrl(`/v1/admin/daily-cancellations-breakdown?date=${encodeURIComponent(dateISO)}`);
+  const res = await fetch(url, { headers: getAuthHeaders() });
+  if (!res.ok) throw new Error(`Failed to load cancellations breakdown: ${res.status} ${res.statusText}`);
+  return res.json(); // { venue, services, events, total }
+}
+

--- a/front-end/src/components/admin/AdminDashboard.js
+++ b/front-end/src/components/admin/AdminDashboard.js
@@ -88,6 +88,10 @@ const AdminDashboard = () => {
         revenueByOrganizer: Array.isArray(dash?.revenueByOrganizer) ? dash.revenueByOrganizer : [],
         venueUtilizationRate: dash?.venueUtilizationRate != null ? Number(dash.venueUtilizationRate) : null,
         serviceProviderUtilizationRate: dash?.serviceProviderUtilizationRate != null ? Number(dash.serviceProviderUtilizationRate) : null,
+        venueActiveNow: dash?.venueActiveNow ?? 0,
+        venueTotal: dash?.venueTotal ?? 0,
+        serviceActiveNow: dash?.serviceProvidersActiveNow ?? 0,
+        serviceTotal: dash?.serviceProvidersTotal ?? 0,
       });
     } catch (error) {
       console.error("Error loading dashboard data:", error);
@@ -303,20 +307,22 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
             gap: '1.5rem',
             marginBottom: '2rem'
           }}>
-            <div className="card text-center">
-              <h3 className="text-warning">{venueUtilization}%</h3>
-              <p className="text-muted">Venue Utilization Rate</p>
-              <small>
-                ({dashboardData.venues ? dashboardData.venues.filter(v => v.bookings && v.bookings.length > 0).length : 0} of {dashboardData.venues ? dashboardData.venues.length : 0} venues booked)
-              </small>
-            </div>
-            <div className="card text-center">
-              <h3 className="text-danger">{serviceUtilization}%</h3>
-              <p className="text-muted">Service Providers Utilization Rate</p>
-              <small>
-                ({dashboardData.services ? dashboardData.services.filter(s => s.bookings && s.bookings.length > 0).length : 0} of {dashboardData.services ? dashboardData.services.length : 0} services booked)
-              </small>
-           </div>
+          <div className="card text-center">
+            <h3 className="text-warning">{venueUtilization}%</h3>
+            <p className="text-muted">Venue Utilization Rate</p>
+            <small>
+              ({dashboardData.venueActiveNow} of {dashboardData.venueTotal} venues booked)
+            </small>
+          </div>
+
+          <div className="card text-center">
+            <h3 className="text-danger">{serviceUtilization}%</h3>
+            <p className="text-muted">Service Providers Utilization Rate</p>
+            <small>
+              ({dashboardData.serviceActiveNow} of {dashboardData.serviceTotal} providers active)
+            </small>
+          </div>
+
           <div className="card" style={{ display: 'grid', gap: '0.5rem' }}>
           <h4 className="mb-1" style={{ marginBottom: 0 }}>Event Type Distribution</h4>
           {eventTypeTotal > 0 ? (

--- a/front-end/src/components/admin/AdminDashboard.js
+++ b/front-end/src/components/admin/AdminDashboard.js
@@ -2,39 +2,160 @@ import React, { useState, useEffect } from "react";
 import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
 import UserManagement from "./UserManagement";
 import EventMonitoring from "./EventMonitoring";
-import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  RadialBarChart, RadialBar, PolarAngleAxis
+} from "recharts";
 import "./AdminDashboard.css";
-import { getAdminDashboard,
+import {
+  getAdminDashboard,
   getEventTypeDistribution,
   getDailyBookings,
   getDailyCancellations,
- } from "../../api/adminApi";
+} from "../../api/adminApi";
 
+/** ---------- Shared chart card wrapper (keeps all charts same height) ---------- */
+const ChartCard = ({ title, children, footer, pad = "1rem" }) => (
+  <div
+    className="card"
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      height: 420,          // <- unified height for all 4 chart cards
+      padding: pad,
+      gap: "0.5rem",
+    }}
+  >
+    {title && <h4 className="mb-1" style={{ marginBottom: 0 }}>{title}</h4>}
+    <div style={{ flex: 1, minHeight: 0 }}>{children}</div>
+    {footer && <small className="text-muted">{footer}</small>}
+  </div>
+);
+/** --------------------------------------------------------------------------- */
+
+/** ---------- Detailed Utilization panel (radial gauge + progress + numbers) -- */
+const UtilizationPanel = ({
+  valuePct,                // 0..100
+  used,                    // number used/active
+  total,                   // total capacity
+  title,                   // heading
+  color = "#3b82f6",       // main bar color
+}) => {
+  const pct = Math.max(0, Math.min(100, Number(valuePct) || 0));
+  const free = Math.max(0, (Number(total) || 0) - (Number(used) || 0));
+
+  // Banding for context (green/yellow/red)
+  const bands = [
+    { name: "Safe",     value: Math.min(pct, 60),        fill: "#22c55e" }, // 0-60%
+    { name: "Warning",  value: Math.max(0, Math.min(pct - 60, 25)), fill: "#f59e0b" }, // 60-85%
+    { name: "Critical", value: Math.max(0, pct - 85),    fill: "#ef4444" }, // 85-100%
+  ].filter(d => d.value > 0);
+
+  const series = [{ name: "Utilization", value: pct, fill: color }];
+
+  return (
+    <ChartCard
+      title={title}
+      footer={`Used ${used ?? 0} • Free ${free < 0 ? 0 : free} • Total ${total ?? 0}`}
+    >
+      {/* Top: radial band (background context) + foreground utilization needle */}
+      <div style={{ width: "100%", height: "70%", marginTop: 44 }}>
+        <ResponsiveContainer width="100%" height="100%">
+        <RadialBarChart
+          innerRadius="56%"
+          outerRadius="100%"
+          startAngle={180}
+          endAngle={0}
+          data={[...bands, ...series]}
+        >
+            <PolarAngleAxis
+              type="number"
+              domain={[0, 100]}
+              angleAxisId={0}
+              tick={false}
+            />
+            {/* Context bands */}
+            {bands.length > 0 && (
+              <RadialBar
+                dataKey="value"
+                clockWise
+                stackId="bg"
+                cornerRadius={8}
+                fillOpacity={0.25}
+              />
+            )}
+            {/* Foreground utilization */}
+            <RadialBar
+              dataKey="value"
+              clockWise
+              stackId="fg"
+              cornerRadius={16}
+              background
+              label={{
+                position: "center",
+                formatter: () => `${Math.round(pct)}%`,
+                fill: "#111827",
+                fontSize: 24,
+                fontWeight: 700,
+              }}
+            />
+            <Tooltip
+              formatter={(val, _name) => [`${Math.round(pct)}% (used ${used ?? 0}, free ${free < 0 ? 0 : free})`, "Utilization"]}
+            />
+          </RadialBarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Bottom: compact horizontal progress with % text */}
+      <div
+        aria-label="utilization-progress"
+        style={{
+          height: 10,
+          borderRadius: 999,
+          background: "#e5e7eb",
+          overflow: "hidden",
+          marginTop: 8,
+        }}
+        title={`${Math.round(pct)}%`}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: "100%",
+            background: color,
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: 12,
+          color: "#6b7280",
+          marginTop: 4,
+        }}
+      >
+        <span>0%</span>
+        <span>{Math.round(pct)}%</span>
+        <span>100%</span>
+      </div>
+    </ChartCard>
+  );
+};
+/** --------------------------------------------------------------------------- */
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [dashboardData, setDashboardData] = useState({
-    users: {
-      admins: 0,
-      eventOrganizers: 0,
-      eventAttendees: 0,
-      serviceProviders: 0,
-      venueProviders: 0
-    },
-    events: {
-      upcoming: 0,
-      ongoing: 0,
-      completed: 0,
-      cancelled: 0
-    },
+    users: { admins: 0, eventOrganizers: 0, eventAttendees: 0, serviceProviders: 0, venueProviders: 0 },
+    events: { upcoming: 0, ongoing: 0, completed: 0, cancelled: 0 },
     venues: [],
     services: [],
     eventTypes: {},
-    dailyStats: {
-      bookings: 0,
-      cancellations: 0
-    },
+    dailyStats: { bookings: 0, cancellations: 0 },
     revenueByOrganizer: [],
     venueUtilizationRate: null,
     serviceProviderUtilizationRate: null,
@@ -42,25 +163,20 @@ const AdminDashboard = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    loadDashboardData();
-  }, []);
+  useEffect(() => { loadDashboardData(); }, []);
 
   const loadDashboardData = async () => {
     try {
       setLoading(true);
       setError(null);
-      // CHANGE: fetch all required datasets in parallel
-      // use the user's local day:  YYYY-MM-DD
-      const todayLocalISO = new Date().toLocaleDateString('en-CA'); // e.g. "2025-09-15"
+      const todayLocalISO = new Date().toLocaleDateString('en-CA');
       const [dash, types, dailyB, dailyC] = await Promise.all([
-        getAdminDashboard(),               // totals + utilization
-        getEventTypeDistribution(),        // map<string, number>
-        getDailyBookings(todayLocalISO, todayLocalISO),    // map<YYYY-MM-DD, number>
+        getAdminDashboard(),
+        getEventTypeDistribution(),
+        getDailyBookings(todayLocalISO, todayLocalISO),
         getDailyCancellations(todayLocalISO, todayLocalISO)
       ]);
 
-      // Sum the (start..end) window (today => single key)
       const num = v => Number(v) || 0;
       const bookings = dailyB ? Object.values(dailyB).map(num).reduce((a, b) => a + b, 0) : 0;
       const cancellations = dailyC ? Object.values(dailyC).map(num).reduce((a, b) => a + b, 0) : 0;
@@ -79,8 +195,6 @@ const AdminDashboard = () => {
           completed: dash?.totalCompleted ?? 0,
           cancelled: dash?.totalCancelled ?? 0
         },
-        // leave these arrays if you plan to populate them later;
-        // they’re no longer used for utilization percentages
         venues: [],
         services: [],
         eventTypes: types || {},
@@ -96,13 +210,11 @@ const AdminDashboard = () => {
     } catch (error) {
       console.error("Error loading dashboard data:", error);
       setError(error.message);
-      // Keep default data structure on error
     } finally {
       setLoading(false);
     }
   };
 
-  // CHANGE: prefer server-provided utilization (if available), otherwise fall back to array-based calc
   const venueUtilization = typeof dashboardData.venueUtilizationRate === 'number'
     ? Math.round(dashboardData.venueUtilizationRate * 100)
     : (dashboardData.venues && dashboardData.venues.length > 0
@@ -110,67 +222,109 @@ const AdminDashboard = () => {
         : 0);
 
   const serviceUtilization = typeof dashboardData.serviceProviderUtilizationRate === 'number'
-    ? Math.round(dashboardData.serviceProviderUtilizationRate*100)
+    ? Math.round(dashboardData.serviceProviderUtilizationRate * 100)
     : (dashboardData.services && dashboardData.services.length > 0
         ? Math.round((dashboardData.services.filter(s => s.bookings && s.bookings.length > 0).length / dashboardData.services.length) * 100)
         : 0);
- 
-  const eventStatusData = [
-    { name: "Upcoming", value: dashboardData.events.upcoming, color: "#ffc107" },
-    { name: "Ongoing", value: dashboardData.events.ongoing, color: "#28a745" },
-    { name: "Completed", value: dashboardData.events.completed, color: "#6c757d" },
-    { name: "Cancelled", value: dashboardData.events.cancelled, color: "#dc3545" }
-  ].filter(item => item.value > 0);
 
   const eventTypeData = Object.entries(dashboardData.eventTypes || {}).map(([type, count]) => ({
     name: type.replace(/_/g, ' '),
     count
   }));
-
-    // === Event Type % helpers ===
   const eventTypeTotal = eventTypeData.reduce((sum, d) => sum + (d.count || 0), 0);
-  const eventTypePieData = eventTypeData.map(d => ({
-    name: d.name,
-    value: d.count,
-    pct: eventTypeTotal ? (d.count / eventTypeTotal) * 100 : 0
-  }));
+  const eventTypePieData = eventTypeData.map(d => ({ name: d.name, value: d.count }));
 
-  // App-friendly palette (keeps your current aesthetic)
+  const totalRevenue = dashboardData.revenueByOrganizer.reduce((sum, r) => sum + (r.revenue || 0), 0);
   const PALETTE = ['#3b82f6', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#17a2b8', '#ec4899', '#6c757d'];
 
-  // Smaller, positioned % labels to avoid legend overlap
-const RADIAN = Math.PI / 180;
-const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
-  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
-  const x = cx + radius * Math.cos(-midAngle * RADIAN);
-  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+  const formatMoneyShort = (n) => {
+    const v = Number(n) || 0;
+    if (v >= 1_000_000_000) return (v / 1_000_000_000).toFixed(1) + 'B';
+    if (v >= 1_000_000)     return (v / 1_000_000).toFixed(1) + 'M';
+    if (v >= 1_000)         return (v / 1_000).toFixed(1) + 'K';
+    return v.toString();
+  };
 
-  return (
-    <text
-      x={x}
-      y={y}
-      fill="#fff"
-      textAnchor="middle"
-      dominantBaseline="central"
-      fontSize={12}      // smaller %
-      style={{ pointerEvents: 'none' }}
-    >
-      {`${Math.round(percent * 100)}%`}
-    </text>
-  );
-};
+  const revenueChartData = dashboardData.revenueByOrganizer.map((r, i) => ({
+    name: r.name,
+    revenue: r.revenue || 0,
+    pct: totalRevenue ? ((r.revenue || 0) / totalRevenue) * 100 : 0,
+    fill: PALETTE[i % PALETTE.length],
+  }));
 
-
-
-  
-  const isMainDashboard = location.pathname === '/' || location.pathname === '/admin' || location.pathname === '';
-
-  
-  useEffect(() => {
-    if (isMainDashboard && location.pathname !== '/') {
-      console.log("Redirecting to main admin dashboard");
+  // Word wrap for outside labels
+  const wrapWords = (text, maxPerLine = 12, maxLines = 2) => {
+    const words = (text || "").split(/\s+/);
+    const lines = [];
+    let line = "";
+    for (const w of words) {
+      const tryLine = line ? line + " " + w : w;
+      if (tryLine.length <= maxPerLine) {
+        line = tryLine;
+      } else {
+        if (line) lines.push(line);
+        line = w;
+        if (lines.length === maxLines - 1) break;
+      }
     }
-  }, [location.pathname, isMainDashboard]);
+    if (line && lines.length < maxLines) lines.push(line);
+    const used = lines.join(" ").length;
+    const leftover = (text || "").slice(used).trim();
+    if (leftover.length > 0) {
+      const last = lines.pop() || "";
+      const trimmed = last.length > 1 ? last.slice(0, Math.max(1, maxPerLine - 1)) + "…" : last + "…";
+      lines.push(trimmed);
+    }
+    return lines;
+  };
+
+  const LABEL_RADIUS_FACTOR = 1.30;
+  const CLAMP_RADIUS_FACTOR = 1.50;
+  const CHAR_WIDTH_FACTOR   = 0.62;
+
+  const renderOutsideLabel = ({ cx, cy, midAngle, outerRadius, percent, name }) => {
+    const RAD = Math.PI / 180;
+    const slices = eventTypePieData.length;
+    const font = slices <= 4 ? 14 : slices <= 6 ? 12 : 10;
+    const maxPerLine = slices <= 4 ? 14 : slices <= 6 ? 12 : 11;
+
+    const r = outerRadius * LABEL_RADIUS_FACTOR;
+    let x = cx + r * Math.cos(-midAngle * RAD);
+    let y = cy + r * Math.sin(-midAngle * RAD);
+
+    const maxR = outerRadius * CLAMP_RADIUS_FACTOR;
+    const pad = 8;
+    const minX = cx - maxR + pad;
+    const maxX = cx + maxR - pad;
+    const minY = cy - maxR + pad;
+    const maxY = cy + maxR - pad;
+
+    x = Math.max(minX, Math.min(maxX, x));
+    y = Math.max(minY, Math.min(maxY, y));
+
+    const anchor = x >= cx ? "start" : "end";
+    const lines = wrapWords(name || "", maxPerLine, 2);
+    const pctText = `• ${Math.round(percent * 100)}%`;
+
+    const estWidth = (s) => s.length * font * CHAR_WIDTH_FACTOR;
+    let last = lines[lines.length - 1] || "";
+    if (estWidth(last + " " + pctText) > (maxR * 0.9)) {
+      last = last.slice(0, Math.max(1, last.length - 3)) + "…";
+    }
+
+    return (
+      <text x={x} y={y} textAnchor={anchor} dominantBaseline="central" fontSize={font} fill="#334155">
+        {lines.slice(0, -1).map((ln, i) => (
+          <tspan key={i} x={x} dy={i === 0 ? 0 : font + 2}>{ln}</tspan>
+        ))}
+        <tspan x={x} dy={lines.length > 1 ? font + 2 : 0}>
+          {lines.length > 0 ? `${last} ${pctText}` : pctText}
+        </tspan>
+      </text>
+    );
+  };
+
+  const isMainDashboard = location.pathname === '/' || location.pathname === '/admin' || location.pathname === '';
 
   if (loading) {
     return (
@@ -191,8 +345,8 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
           <p style={{ color: '#6c757d', marginBottom: '1.5rem' }}>
             Unable to fetch dashboard data: {error}
           </p>
-          <button 
-            onClick={loadDashboardData} 
+          <button
+            onClick={loadDashboardData}
             className="btn btn-primary"
             style={{ padding: '0.75rem 1.5rem' }}
           >
@@ -205,7 +359,6 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
 
   return (
     <div style={{ width: '98vw', maxWidth: '98vw', margin: "10px auto", padding: '0 10px' }}>
-      {/* Only show this if we're not on a sub-route */}
       {isMainDashboard && (
         <>
           <h2 style={{ textAlign: "center", marginBottom: 24, color: "#2c3e50", fontSize: "2.5rem", fontWeight: 700 }}>
@@ -214,7 +367,7 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
           <p style={{ textAlign: "center", marginBottom: 32, color: "#6c757d", fontSize: "1.1rem" }}>
             Monitor and control the entire event management system
           </p>
-          
+
           {/* Navigation Cards */}
           <div style={{
             display: 'grid',
@@ -226,8 +379,6 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
               className="card text-center"
               style={{ cursor: 'pointer', border: '2px solid #3b82f6', transition: 'all 0.3s ease' }}
               onClick={() => navigate('/admin/user-management')}
-              onMouseEnter={(e) => e.target.style.transform = 'translateY(-4px)'}
-              onMouseLeave={(e) => e.target.style.transform = 'translateY(0)'}
             >
               <h3 className="text-primary">{Object.values(dashboardData.users).reduce((a, b) => a + b, 0)}</h3>
               <p className="text-muted">Total Users</p>
@@ -237,37 +388,10 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
               className="card text-center"
               style={{ cursor: 'pointer', border: '2px solid #28a745', transition: 'all 0.3s ease' }}
               onClick={() => navigate('/admin/event-monitoring')}
-              onMouseEnter={(e) => e.target.style.transform = 'translateY(-4px)'}
-              onMouseLeave={(e) => e.target.style.transform = 'translateY(0)'}
             >
               <h3 className="text-success">{Object.values(dashboardData.events).reduce((a, b) => a + b, 0)}</h3>
               <p className="text-muted">Total Events</p>
               <small className="text-success">Click to manage events →</small>
-            </div>
-          </div>
-
-          {/* Total Events by Status - Pie Chart */}
-          <div className="card mb-4">
-            <h4 className="mb-3">Total Events by Status</h4>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '2rem', alignItems: 'center' }}>
-              <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: '1rem'
-              }}>
-                <div className="status-badge status-pending">
-                  Upcoming: {dashboardData.events.upcoming}
-                </div>
-                <div className="status-badge status-confirmed">
-                  Ongoing: {dashboardData.events.ongoing}
-                </div>
-                <div className="status-badge status-completed">
-                  Completed: {dashboardData.events.completed}
-                </div>
-                <div className="status-badge status-cancelled">
-                  Cancelled: {dashboardData.events.cancelled}
-                </div>
-              </div>
             </div>
           </div>
 
@@ -276,103 +400,109 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
             <h4 className="mb-3">User Breakdown</h4>
             <table className="table">
               <tbody>
-                <tr>
-                  <td>Admins</td>
-                  <td className="text-right fw-bold">{dashboardData.users.admins}</td>
-                </tr>
-                <tr>
-                  <td>Event Organizers</td>
-                  <td className="text-right fw-bold">{dashboardData.users.eventOrganizers}</td>
-                </tr>
-                <tr>
-                  <td>Event Attendees</td>
-                  <td className="text-right fw-bold">{dashboardData.users.eventAttendees}</td>
-                </tr>
-                <tr>
-                  <td>Service Providers</td>
-                  <td className="text-right fw-bold">{dashboardData.users.serviceProviders}</td>
-                </tr>
-                <tr>
-                  <td>Venue Providers</td>
-                  <td className="text-right fw-bold">{dashboardData.users.venueProviders}</td>
-                </tr>
+                <tr><td>Admins</td><td className="text-right fw-bold">{dashboardData.users.admins}</td></tr>
+                <tr><td>Event Organizers</td><td className="text-right fw-bold">{dashboardData.users.eventOrganizers}</td></tr>
+                <tr><td>Event Attendees</td><td className="text-right fw-bold">{dashboardData.users.eventAttendees}</td></tr>
+                <tr><td>Service Providers</td><td className="text-right fw-bold">{dashboardData.users.serviceProviders}</td></tr>
+                <tr><td>Venue Providers</td><td className="text-right fw-bold">{dashboardData.users.venueProviders}</td></tr>
               </tbody>
             </table>
           </div>
 
-          {/* Utilization Rates and statistics cards */}
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-            gap: '1.5rem',
-            marginBottom: '2rem'
-          }}>
-          <div className="card text-center">
-            <h3 className="text-warning">{venueUtilization}%</h3>
-            <p className="text-muted">Venue Utilization Rate</p>
-            <small>
-              ({dashboardData.venueActiveNow} of {dashboardData.venueTotal} venues booked)
-            </small>
-          </div>
+          {/* === Four balanced chart cards === */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+              gap: '1.5rem',
+              marginBottom: '2rem'
+            }}
+          >
+            <UtilizationPanel
+              title="Venue Utilization"
+              valuePct={venueUtilization}
+              used={dashboardData.venueActiveNow}
+              total={dashboardData.venueTotal}
+              color="#f59e0b"
+            />
 
-          <div className="card text-center">
-            <h3 className="text-danger">{serviceUtilization}%</h3>
-            <p className="text-muted">Service Providers Utilization Rate</p>
-            <small>
-              ({dashboardData.serviceActiveNow} of {dashboardData.serviceTotal} providers active)
-            </small>
-          </div>
+            <UtilizationPanel
+              title="Service Providers Utilization"
+              valuePct={serviceUtilization}
+              used={dashboardData.serviceActiveNow}
+              total={dashboardData.serviceTotal}
+              color="#ef4444"
+            />
 
-          <div className="card" style={{ display: 'grid', gap: '0.5rem' }}>
-          <h4 className="mb-1" style={{ marginBottom: 0 }}>Event Type Distribution</h4>
-          {eventTypeTotal > 0 ? (
-            <div style={{ height: 260 }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={eventTypePieData}
-                    dataKey="value"
-                    nameKey="name"
-                    innerRadius={60}
-                    outerRadius={100}
-                    label={renderPctLabel}
-                    labelLine={false}
-                  >
-                    {eventTypePieData.map((entry, i) => (
-                      <Cell key={`slice-${i}`} fill={PALETTE[i % PALETTE.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip
-                    formatter={(value, name) =>
-                      [`${((value / eventTypeTotal) * 100).toFixed(1)}% (${value})`, name]
-                    }
-                  />
-                  <Legend verticalAlign="bottom" iconType="circle" />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-          ) : (
-            <p className="text-muted" style={{ margin: '0.5rem 0 0.75rem' }}>
-              No event types yet.
-            </p>
-          )}
-          <small className="text-muted">
-            Showing percentage share (hover for exact counts).
-          </small>
-        </div>
+            <ChartCard
+              title="Event Type Distribution"
+              footer="Hover a slice for exact counts."
+            >
+              {eventTypeTotal > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart margin={{ top: -6, right: 32, bottom: 16, left: 32 }}>
+                    <Pie
+                      data={eventTypePieData}
+                      dataKey="value"
+                      nameKey="name"
+                      innerRadius={62}
+                      outerRadius={96}
+                      label={renderOutsideLabel}
+                      labelLine
+                      cx="50%"
+                      cy="52%"
+                    >
+                      {eventTypePieData.map((entry, i) => (
+                        <Cell key={`slice-${i}`} fill={PALETTE[i % PALETTE.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      formatter={(value, name) => [
+                        `${((value / eventTypeTotal) * 100).toFixed(1)}% (${value})`,
+                        name
+                      ]}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+              ) : (
+                <p className="text-muted" style={{ margin: '0.5rem 0 0.75rem' }}>No event types yet.</p>
+              )}
+            </ChartCard>
 
-            {/* Revenue per Organizer Statistic */}
-            <div className="card text-center">
-              <h3 className="text-success">
-                ${dashboardData.revenueByOrganizer ? dashboardData.revenueByOrganizer.reduce((a, b) => a + (b.revenue || 0), 0).toLocaleString() : '0'}
-              </h3>
-              <p className="text-muted">Total Revenue (Organizers)</p>
-              <small>
-                {dashboardData.revenueByOrganizer && dashboardData.revenueByOrganizer.length > 0 
-                  ? dashboardData.revenueByOrganizer.map(ro => `${ro.name}: $${(ro.revenue || 0).toLocaleString()}`).join(', ') 
-                  : 'No revenue'}
-              </small>
-            </div>
+            <ChartCard
+              title="Revenue per Organizer"
+              footer="Bars are color-coded; hover to see exact amount and % of total."
+              pad="1rem"
+            >
+              {revenueChartData.length > 0 ? (
+                // add this wrapper ↓
+                <div style={{ height: "100%", marginTop: 12 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={revenueChartData} margin={{ top: 16, right: 24, left: 8, bottom: 24 }}>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="name" interval={0} angle={-20} dy={12} height={60} tick={{ fontSize: 12 }} />
+                      <YAxis tickFormatter={formatMoneyShort} width={48} />
+                      <Tooltip
+                        formatter={(value, _name, props) => [
+                          `$${Number(value).toLocaleString()} (${props?.payload?.pct?.toFixed(1)}%)`,
+                          "Revenue",
+                        ]}
+                      />
+                      {/* remove the Legend to hide the “revenue” label */}
+                      {/* <Legend /> */}
+                      <Bar dataKey="revenue" isAnimationActive>
+                        {revenueChartData.map((entry, idx) => (
+                          <Cell key={`cell-${idx}`} fill={entry.fill} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <p className="text-muted">No revenue data available</p>
+              )}
+            </ChartCard>
+
           </div>
 
           {/* Daily Stats */}
@@ -397,12 +527,7 @@ const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent })
       <Routes>
         <Route path="user-management" element={<UserManagement />} />
         <Route path="event-monitoring" element={<EventMonitoring />} />
-        <Route path="/" element={
-          <div>
-            {/* Main dashboard content */}
-            {/* This will only show when we're on the exact root path */}
-          </div>
-        } />
+        <Route path="/" element={<div />} />
       </Routes>
     </div>
   );

--- a/front-end/src/components/admin/AdminDashboard.js
+++ b/front-end/src/components/admin/AdminDashboard.js
@@ -123,6 +123,41 @@ const AdminDashboard = () => {
     count
   }));
 
+    // === Event Type % helpers ===
+  const eventTypeTotal = eventTypeData.reduce((sum, d) => sum + (d.count || 0), 0);
+  const eventTypePieData = eventTypeData.map(d => ({
+    name: d.name,
+    value: d.count,
+    pct: eventTypeTotal ? (d.count / eventTypeTotal) * 100 : 0
+  }));
+
+  // App-friendly palette (keeps your current aesthetic)
+  const PALETTE = ['#3b82f6', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#17a2b8', '#ec4899', '#6c757d'];
+
+  // Smaller, positioned % labels to avoid legend overlap
+const RADIAN = Math.PI / 180;
+const renderPctLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
+  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="#fff"
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={12}      // smaller %
+      style={{ pointerEvents: 'none' }}
+    >
+      {`${Math.round(percent * 100)}%`}
+    </text>
+  );
+};
+
+
+
   
   const isMainDashboard = location.pathname === '/' || location.pathname === '/admin' || location.pathname === '';
 
@@ -281,15 +316,45 @@ const AdminDashboard = () => {
               <small>
                 ({dashboardData.services ? dashboardData.services.filter(s => s.bookings && s.bookings.length > 0).length : 0} of {dashboardData.services ? dashboardData.services.length : 0} services booked)
               </small>
+           </div>
+          <div className="card" style={{ display: 'grid', gap: '0.5rem' }}>
+          <h4 className="mb-1" style={{ marginBottom: 0 }}>Event Type Distribution</h4>
+          {eventTypeTotal > 0 ? (
+            <div style={{ height: 260 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={eventTypePieData}
+                    dataKey="value"
+                    nameKey="name"
+                    innerRadius={60}
+                    outerRadius={100}
+                    label={renderPctLabel}
+                    labelLine={false}
+                  >
+                    {eventTypePieData.map((entry, i) => (
+                      <Cell key={`slice-${i}`} fill={PALETTE[i % PALETTE.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value, name) =>
+                      [`${((value / eventTypeTotal) * 100).toFixed(1)}% (${value})`, name]
+                    }
+                  />
+                  <Legend verticalAlign="bottom" iconType="circle" />
+                </PieChart>
+              </ResponsiveContainer>
             </div>
-            {/* Event Type Distribution Statistic */}
-            <div className="card text-center">
-              <h3 className="text-primary">{eventTypeData.reduce((a, b) => a + (b.count || 0), 0)}</h3>
-              <p className="text-muted">Event Type Distribution</p>
-              <small>
-                {eventTypeData.map(et => `${et.name}: ${et.count}`).join(', ') || 'No event types'}
-              </small>
-            </div>
+          ) : (
+            <p className="text-muted" style={{ margin: '0.5rem 0 0.75rem' }}>
+              No event types yet.
+            </p>
+          )}
+          <small className="text-muted">
+            Showing percentage share (hover for exact counts).
+          </small>
+        </div>
+
             {/* Revenue per Organizer Statistic */}
             <div className="card text-center">
               <h3 className="text-success">

--- a/front-end/src/components/event-attendee/AttendeeActivities.js
+++ b/front-end/src/components/event-attendee/AttendeeActivities.js
@@ -1,0 +1,249 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getBookingsByAttendeeId } from "../../api/bookingApi";
+import { getEventById } from "../../api/eventApi"; // hydrate event details when needed
+import { keycloakSettings } from "../../config/keycloakConfig";
+
+const dateSafe = (d) => (d ? new Date(d) : null);
+const fmtDate = (d) => (d ? new Date(d).toLocaleDateString() : "TBD");
+const fmtTime = (d) =>
+  d ? new Date(d).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
+
+const isConfirmed = (s) =>
+  ["ACCEPTED", "CONFIRMED", "APPROVED", "REGISTERED"].includes((s || "").toUpperCase());
+
+export default function AttendeeActivities() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [bookings, setBookings] = useState([]);
+  const [error, setError] = useState(null);
+
+  // Derive attendee id: prefer Keycloak, then a localStorage fallback if you store it
+  const attendeeId =
+    keycloakSettings?.tokenParsed?.sub ||
+    JSON.parse(localStorage.getItem("kcTokenParsed") || "{}")?.sub ||
+    null;
+
+  // Hydrate bookings with event details if missing
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        if (!attendeeId) {
+          setBookings([]);
+          return;
+        }
+
+        const raw = await getBookingsByAttendeeId(attendeeId);
+
+        // fetch any missing event objects in parallel
+        const needsFetch = raw.filter((b) => !b.event && (b.eventId || b.event_id));
+        const fetchedMap = new Map();
+        await Promise.all(
+          needsFetch.map(async (b) => {
+            try {
+              const id = b.eventId || b.event_id;
+              if (!id || fetchedMap.has(id)) return;
+              const ev = await getEventById(id);
+              fetchedMap.set(id, ev);
+            } catch (_e) {
+              // ignore per-booking failures; we'll render partial data
+            }
+          })
+        );
+
+        // normalize unified shape used by UI
+        const normalized = raw.map((b) => {
+          const ev = b.event || fetchedMap.get(b.eventId || b.event_id) || {};
+          const start = dateSafe(ev.startTime || b.startTime);
+          const end = dateSafe(ev.endTime || b.endTime);
+          return {
+            bookingId: b.id,
+            status: b.status || "PENDING",
+            eventId: ev.id || b.eventId || b.event_id,
+            name: ev.name || b.eventName || "Untitled Event",
+            location: ev.location || ev.venue || "TBD",
+            startTime: start,
+            endTime: end,
+          };
+        });
+
+        if (alive) setBookings(normalized);
+      } catch (e) {
+        console.error(e);
+        if (alive) {
+          setError("Failed to load your activities. Please try again.");
+          setBookings([]);
+        }
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [attendeeId]);
+
+  // Segment into Previous / Current / Upcoming
+  const now = new Date();
+  const { previous, current, upcoming } = useMemo(() => {
+    const prev = [];
+    const cur = [];
+    const up = [];
+
+    bookings.forEach((b) => {
+      const { startTime: s, endTime: e, status } = b;
+      // If we have no times, don’t break—treat as upcoming when confirmed, else ignore
+      if (!s && !e) {
+        if (isConfirmed(status)) up.push(b);
+        return;
+      }
+      // classify with safe guards
+      if (e && e < now) {
+        prev.push(b);
+      } else if (s && e && s <= now && now <= e) {
+        cur.push(b);
+      } else if (s && s > now) {
+        up.push(b);
+      } else {
+        // fallback: if confirmed but missing an end, treat as upcoming
+        if (isConfirmed(status)) up.push(b);
+      }
+    });
+
+    // sort: upcoming by soonest first; previous by newest first
+    up.sort((a, b) => (a.startTime || Infinity) - (b.startTime || Infinity));
+    prev.sort((a, b) => (b.endTime || -Infinity) - (a.endTime || -Infinity));
+
+    // only one "current" highlighted (choose the one ending soonest)
+    cur.sort((a, b) => (a.endTime || Infinity) - (b.endTime || Infinity));
+    return { previous: prev, current: cur[0] || null, upcoming: up };
+  }, [bookings]);
+
+  const EventCard = ({ item }) => (
+    <div className="card" style={{ borderRadius: 12, padding: 16 }}>
+      <div className="booking-card-header" style={{ marginBottom: 8 }}>
+        <h5 className="booking-card-title" style={{ margin: 0 }}>{item.name}</h5>
+        <span className={`status-badge status-${String(item.status || "").toLowerCase()}`}>
+          {item.status}
+        </span>
+      </div>
+      <div className="booking-card-content">
+        <p style={{ margin: "4px 0" }}>📅 {fmtDate(item.startTime)}</p>
+        <p style={{ margin: "4px 0" }}>
+          ⏰ {fmtTime(item.startTime)}{item.endTime ? ` – ${fmtTime(item.endTime)}` : ""}
+        </p>
+        <p style={{ margin: "4px 0" }}>📍 {item.location}</p>
+      </div>
+      <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+        {item.eventId ? (
+          <button
+            className="event-btn secondary"
+            onClick={() => navigate(`/events/${item.eventId}`)}
+          >
+            View Details
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="event-section">
+        <h4 className="section-title">My Activities</h4>
+        <div className="empty-state">
+          <h5>Loading…</h5>
+          <p>Fetching your events and bookings.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="event-section">
+        <h4 className="section-title">My Activities</h4>
+        <div className="empty-state">
+          <h5>Couldn’t load activities</h5>
+          <p>{error}</p>
+          <button className="event-btn" onClick={() => window.location.reload()}>Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="event-section">
+      <div className="section-header">
+        <h4 className="section-title">My Activities</h4>
+      </div>
+
+      {/* Current Event */}
+      <div className="card" style={{ padding: 16, marginBottom: 20 }}>
+        <h5 style={{ marginTop: 0, marginBottom: 12, color: "#2c3e50" }}>Current Event</h5>
+        {!current ? (
+          <div className="empty-state">
+            <h5>No event is ongoing right now</h5>
+            <p>Check your upcoming list or browse new events.</p>
+            <button className="event-btn success" onClick={() => navigate("/events")}>
+              Browse Events
+            </button>
+          </div>
+        ) : (
+          <EventCard item={current} />
+        )}
+      </div>
+
+      {/* Upcoming */}
+      <div className="card" style={{ padding: 16, marginBottom: 20 }}>
+        <div className="section-header" style={{ marginBottom: 8 }}>
+          <h5 style={{ margin: 0, color: "#2c3e50" }}>Upcoming Events</h5>
+          <button className="view-all-btn" onClick={() => navigate("/attendee/bookings")}>
+            View All →
+          </button>
+        </div>
+        {upcoming.length === 0 ? (
+          <div className="empty-state">
+            <h5>No upcoming events</h5>
+            <p>You haven’t booked any future events yet.</p>
+            <button className="event-btn secondary" onClick={() => navigate("/events")}>
+              Discover Events
+            </button>
+          </div>
+        ) : (
+          <div
+            className="bookings-grid"
+            style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: 16 }}
+          >
+            {upcoming.map((u) => (
+              <EventCard key={`${u.bookingId}-${u.eventId || u.name}`} item={u} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Previous */}
+      <div className="card" style={{ padding: 16 }}>
+        <h5 style={{ marginTop: 0, marginBottom: 12, color: "#2c3e50" }}>Previous Events</h5>
+        {previous.length === 0 ? (
+          <div className="empty-state">
+            <h5>No past events yet</h5>
+            <p>Your completed and expired events will appear here.</p>
+          </div>
+        ) : (
+          <div
+            style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: 16 }}
+          >
+            {previous.map((p) => (
+              <EventCard key={`${p.bookingId}-${p.eventId || p.name}`} item={p} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/components/event-attendee/AttendeeDashboard.js
+++ b/front-end/src/components/event-attendee/AttendeeDashboard.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { getBookingsByAttendeeId } from "../../api/bookingApi";
 import { getAllEvents } from "../../api/eventApi";
 
+
 const AttendeeDashboard = () => {
     const navigate = useNavigate();
     const [bookings, setBookings] = useState([]);

--- a/front-end/src/components/event-attendee/EventAttendeeDashboard.js
+++ b/front-end/src/components/event-attendee/EventAttendeeDashboard.js
@@ -1,336 +1,366 @@
-import React, { useState, useEffect } from "react";
-//import { getMyServices } from "../../api/serviceApi";
+import React, { useState, useEffect, useMemo } from "react";
 import { getAllEvents } from "../../api/eventApi";
 import { getBookingsByAttendeeId } from "../../api/bookingApi";
-import { keycloakSettings } from "../../config/keycloakConfig"; 
+import { keycloakSettings } from "../../config/keycloakConfig";
 
-
-const initialEvents = [
-  {
-    id: 1,
-    name: "Tech Conference 2024",
-    date: "2024-03-15",
-    time: "09:00",
-    location: "Convention Center",
-    price: 150,
-    organizer: "TechCorp",
-    description: "Latest technology trends and innovations",
-    category: "Technology",
-    status: "Open",
-    attendees: 200,
-    maxAttendees: 500,
-  },
-  {
-    id: 2,
-    name: "Music Festival",
-    date: "2024-04-20",
-    time: "18:00",
-    location: "Central Park",
-    price: 75,
-    organizer: "Music Events",
-    description: "Live music from various artists",
-    category: "Entertainment",
-    status: "Open",
-    attendees: 800,
-    maxAttendees: 1000,
-  },
-];
+const SEGMENTS = ["Past", "Current", "Upcoming"];
 
 const EventAttendeeDashboard = () => {
-  // const [services, setServices] = useState([]);
-  // useEffect(() => {
-  //   (async () => {
-  //     try {
-  //       const svc = await getMyServices();
-  //       setServices(svc);
-  //     } catch (e) {
-  //       // eslint-disable-next-line no-console
-  //       console.error("Failed to load services", e);
-  //     }
-  //   })();
-  // }, []);
-
-  // const [events, setEvents] = useState(() => {
-  //   const organizerEvents = localStorage.getItem("events");
-  //   const storedEvents = organizerEvents ? JSON.parse(organizerEvents) : [];
-  //   return [
-  //     ...initialEvents,
-  //     ...storedEvents.map((event) => ({
-  //       ...event,
-  //       price: event.retailPrice || 100,
-  //       location: event.venue || "TBD",
-  //       organizer: "Event Organizer",
-  //       description: `Event organized with ${
-  //         event.services.length > 0 ? event.services.join(", ") : "basic setup"
-  //       }`,
-  //       category: "General",
-  //       status: "Open",
-  //       attendees: 0,
-  //       maxAttendees: 100,
-  //     })),
-  //   ];
-  // });
-
-
   const [events, setEvents] = useState([]);
-  // Load REAL events from the backend and replace the placeholder list
-useEffect(() => {
-  (async () => {
-    try {
-      // eventApi.getAllEvents already unwraps Spring Page -> returns an array
-      const apiEvents = await getAllEvents(0, 50);
-
-      // Normalize backend fields to what the UI expects
-      const mapped = apiEvents.map(ev => {
-        const start = ev.startTime ? new Date(ev.startTime) : null;
-        return {
-          id: ev.id,
-          name: ev.name ?? ev.title ?? "Untitled Event",
-          date: start ? start.toISOString().slice(0, 10) : "TBD",
-          time: start ? start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "",
-          location: ev.location ?? ev.venue ?? "TBD",
-          price: typeof ev.price === "number"  ? (ev.price > 10000 ? Math.round(ev.price / 100) : ev.price): (ev.retailPrice ?? 0),
-          category: ev.type ?? ev.category ?? "General",
-          attendees: ev.attendeesCount ?? ev.registeredAttendees ?? 0,
-          maxAttendees: ev.capacity ?? ev.maxAttendees ?? 100,
-          status: ev.status ?? "Open",
-          // keep services so your existing description template won’t break
-          services: Array.isArray(ev.services)
-            ? ev.services.map(s => (typeof s === "string" ? s : (s?.name ?? ""))).filter(Boolean)
-            : [],
-        };
-      });
-
-      setEvents(mapped);
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to load events", e);
-    }
-  })();
-}, []);
-
-// Activities from backend (attendee’s own bookings)
-const [myActivities, setMyActivities] = useState([]);
-// Fast membership check for registered status
-const [registeredIds, setRegisteredIds] = useState(new Set());
-
-// Load attendee bookings once
-useEffect(() => {
-  (async () => {
-    try {
-      const attendeeId = keycloakSettings?.tokenParsed?.sub;
-      if (!attendeeId) return;
-
-      const bookings = await getBookingsByAttendeeId(attendeeId);
-
-      // Event IDs you are registered for
-      const regs = new Set(
-        bookings
-          .map(b => b.eventId ?? b.event?.id)
-          .filter(Boolean)
-      );
-      setRegisteredIds(regs);
-
-      // Build activity cards (shown in "My Activities")
-      const activities = bookings
-        .map(b => {
-          const ev = b.event || {};
-          const start = ev.startTime ? new Date(ev.startTime) : null;
-          return {
-            id: b.eventId ?? ev.id,
-            name: ev.name ?? b.eventName ?? "Untitled Event",
-            date: start ? start.toISOString().slice(0, 10) : "TBD",
-            time: start ? start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "",
-            location: ev.location ?? ev.venue ?? "TBD",
-            status: b.status ?? "Registered",
-          };
-        })
-        .filter(a => a.id);
-      setMyActivities(activities);
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to load attendee bookings", e);
-    }
-  })();
-}, []);
-
+  const [registeredIds, setRegisteredIds] = useState(new Set());
 
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [filter, setFilter] = useState("All");
   const [sortBy, setSortBy] = useState("date");
   const [searchTerm, setSearchTerm] = useState("");
-  const [showPayment, setShowPayment] = useState(null);
-  const [activityFilter, setActivityFilter] = useState("All");
-  const [rating, setRating] = useState(0);
-  const [showRating, setShowRating] = useState(null);
 
+  const [showPayment, setShowPayment] = useState(null);
+  const [activeSeg, setActiveSeg] = useState("Current"); // Past | Current | Upcoming
+
+  // --- data loading ----------------------------------------------------------
+  useEffect(() => {
+    (async () => {
+      try {
+        const apiEvents = await getAllEvents(0, 50);
+        const mapped = apiEvents.map((ev) => {
+          const start = ev.startTime ? new Date(ev.startTime) : null;
+          const desc =
+            ev.description ??
+            (Array.isArray(ev.services) && ev.services.length
+              ? `Includes: ${ev.services
+                  .map((s) => (typeof s === "string" ? s : s?.name ?? ""))
+                  .filter(Boolean)
+                  .join(", ")}`
+              : "No description provided.");
+
+          return {
+            id: ev.id,
+            name: ev.name ?? ev.title ?? "Untitled Event",
+            date: start ? start.toISOString().slice(0, 10) : "TBD",
+            time: start
+              ? start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+              : "",
+            startDateObj: start,
+            location: ev.location ?? ev.venue ?? "TBD",
+            price:
+              typeof ev.price === "number"
+                ? ev.price > 10000
+                  ? Math.round(ev.price / 100)
+                  : ev.price
+                : ev.retailPrice ?? 0,
+            category: ev.type ?? ev.category ?? "General",
+            attendees: ev.attendeesCount ?? ev.registeredAttendees ?? 0,
+            maxAttendees: ev.capacity ?? ev.maxAttendees ?? 100,
+            status: ev.status ?? "Open",
+            organizer: ev.organizer ?? "Event Organizer",
+            description: desc,
+          };
+        });
+        setEvents(mapped);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to load events", e);
+      }
+    })();
+  }, []);
+
+  // Already-registered events by this attendee
+  useEffect(() => {
+    (async () => {
+      try {
+        const attendeeId = keycloakSettings?.tokenParsed?.sub;
+        if (!attendeeId) return;
+        const bookings = await getBookingsByAttendeeId(attendeeId);
+        const regs = new Set(
+          bookings.map((b) => b.eventId ?? b.event?.id).filter(Boolean)
+        );
+        setRegisteredIds(regs);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to load attendee bookings", e);
+      }
+    })();
+  }, []);
+
+  // --- utilities -------------------------------------------------------------
+  const isSameDay = (a, b) =>
+    a &&
+    b &&
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+
+  const segmentFor = (ev) => {
+    if (!ev.startDateObj) return "Upcoming"; // unknown -> treat as future
+    const today = new Date();
+    const start = ev.startDateObj;
+    if (isSameDay(start, today)) return "Current";
+    return start < new Date(today.getFullYear(), today.getMonth(), today.getDate())
+      ? "Past"
+      : "Upcoming";
+  };
+
+  // --- search / filter / sort (unchanged behavior) --------------------------
+  const baseFiltered = useMemo(() => {
+    const arr = events
+      .filter((event) => {
+        if (filter !== "All" && event.category !== filter) return false;
+        if (
+          searchTerm &&
+          !event.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+          !event.location.toLowerCase().includes(searchTerm.toLowerCase())
+        )
+          return false;
+        return true;
+      })
+      .sort((a, b) => {
+        if (sortBy === "date") {
+          const ad = a.startDateObj ? a.startDateObj.getTime() : Infinity;
+          const bd = b.startDateObj ? b.startDateObj.getTime() : Infinity;
+          return ad - bd;
+        }
+        if (sortBy === "price") return (a.price ?? 0) - (b.price ?? 0);
+        if (sortBy === "name") return a.name.localeCompare(b.name);
+        return 0;
+      });
+    return arr;
+  }, [events, filter, searchTerm, sortBy]);
+
+  // Split by segment AFTER base filters
+  const segmented = useMemo(() => {
+    const buckets = { Past: [], Current: [], Upcoming: [] };
+    baseFiltered.forEach((ev) => buckets[segmentFor(ev)].push(ev));
+    return buckets;
+  }, [baseFiltered]);
+
+  const counts = {
+    Past: segmented.Past.length,
+    Current: segmented.Current.length,
+    Upcoming: segmented.Upcoming.length,
+  };
+
+  const activeList = segmented[activeSeg];
+
+  // --- actions ---------------------------------------------------------------
   const handleJoinEvent = (event) => {
     if (event.attendees >= event.maxAttendees) {
       alert("Event is full!");
       return;
     }
-    if (registeredIds.has(event.id))  {
+    if (registeredIds.has(event.id)) {
       alert("You are already registered for this event!");
       return;
     }
     setShowPayment(event);
   };
 
-const handlePayment = (event) => {
-  const success = Math.random() > 0.1;
-  if (success) {
-    // Mark as registered in-memory
-    setRegisteredIds(prev => new Set(prev).add(event.id));
-
-    // Add to My Activities
-    setMyActivities(prev => ([
-      ...prev,
-      {
-        id: event.id,
-        name: event.name,
-        date: event.date,
-        time: event.time,
-        location: event.location,
-        status: "Registered",
-      }
-    ]));
-
-    // Bump visible attendees counter
-    setEvents(prev =>
-      prev.map((e) =>
-        e.id === event.id ? { ...e, attendees: (e.attendees || 0) + 1 } : e
-      )
-    );
-
-    alert(
-      "Payment successful! Email confirmation sent. Event reminders will be sent closer to the date."
-    );
-  } else {
-    alert("Payment failed! Please try again. Failure notification email sent.");
-  }
-  setShowPayment(null);
-};
-
-
-const handleCancelRegistration = (eventId) => {
-  const ev = myActivities.find((e) => e.id === eventId);
-  if (!ev) return;
-
-  const eventDate = new Date(ev.date);
-  const today = new Date();
-  const daysDifference = Math.ceil(
-    (eventDate - today) / (1000 * 60 * 60 * 24)
-  );
-  if (daysDifference < 3) {
-    if (
-      !window.confirm(
-        "Cancelling less than 3 days before the event may result in no refund. Continue?"
-      )
-    ) {
-      return;
+  const handlePayment = (event) => {
+    const success = Math.random() > 0.1;
+    if (success) {
+      setRegisteredIds((prev) => new Set(prev).add(event.id));
+      setEvents((prev) =>
+        prev.map((e) =>
+          e.id === event.id ? { ...e, attendees: (e.attendees || 0) + 1 } : e
+        )
+      );
+      alert(
+        "Payment successful! Email confirmation sent. Event reminders will be sent closer to the date."
+      );
+    } else {
+      alert("Payment failed! Please try again. Failure notification email sent.");
     }
-  }
+    setShowPayment(null);
+  };
 
-  // Remove from My Activities
-  setMyActivities(prev => prev.filter((e) => e.id !== eventId));
+  const goLeft = () => {
+    const idx = SEGMENTS.indexOf(activeSeg);
+    setActiveSeg(SEGMENTS[(idx + SEGMENTS.length - 1) % SEGMENTS.length]);
+  };
+  const goRight = () => {
+    const idx = SEGMENTS.indexOf(activeSeg);
+    setActiveSeg(SEGMENTS[(idx + 1) % SEGMENTS.length]);
+  };
 
-  // Drop from registered set
-  setRegisteredIds(prev => {
-    const next = new Set(prev);
-    next.delete(eventId);
-    return next;
-  });
-
-  // Decrement attendees on the browse card
-  setEvents(prev =>
-    prev.map((e) =>
-      e.id === eventId ? { ...e, attendees: Math.max(0, (e.attendees || 0) - 1) } : e
-    )
-  );
-
-  alert("Registration cancelled and email confirmation sent!");
-};
-
-
-const handleRateEvent = (eventId, rating) => {
-  setMyActivities(prev =>
-    prev.map((e) =>
-      e.id === eventId ? { ...e, rating, ratedDate: new Date().toISOString() } : e
-    )
-  );
-  setShowRating(null);
-  setRating(0);
-  alert("Thank you for rating this event!");
-};
-
-  const filteredEvents = events
-    .filter((event) => {
-      if (filter !== "All" && event.category !== filter) return false;
-      if (
-        searchTerm &&
-        !event.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
-        !event.location.toLowerCase().includes(searchTerm.toLowerCase())
-      )
-        return false;
-      return true;
-    })
-    .sort((a, b) => {
-      if (sortBy === "date") return new Date(a.date) - new Date(b.date);
-      if (sortBy === "price") return a.price - b.price;
-      if (sortBy === "name") return a.name.localeCompare(b.name);
-      return 0;
-    });
-
-const filteredMyActivities = myActivities.filter((event) => {
-  const eventDate = new Date(event.date);
-  const today = new Date();
-  if (activityFilter === "Previous") return eventDate < today;
-  if (activityFilter === "Current") {
-    const daysDiff = Math.abs((eventDate - today) / (1000 * 60 * 60 * 24));
-    return daysDiff <= 1;
-  }
-  if (activityFilter === "Upcoming") return eventDate > today;
-  return true;
-});
-
-
+  // --- UI -------------------------------------------------------------------
   return (
     <div style={{ width: "98vw", maxWidth: "98vw", margin: "10px auto", padding: "0 10px" }}>
-      <h2 style={{ textAlign: "center", marginBottom: 24, color: "#2c3e50", fontSize: "2.5rem", fontWeight: 700 }}>
+      <h2
+        style={{
+          textAlign: "center",
+          marginBottom: 24,
+          color: "#2c3e50",
+          fontSize: "2.5rem",
+          fontWeight: 700,
+        }}
+      >
         Event Attendee Dashboard
       </h2>
 
-      {/* Browse Events Section */}
+      {/* Browse Events (with segment deck) */}
       <div className="card" style={{ marginBottom: 24, width: "100%", padding: "1.5rem" }}>
-        <h3 style={{ marginBottom: 20, color: "#2c3e50" }}>Browse Events</h3>
+        <h3 style={{ marginBottom: 10, color: "#2c3e50" }}>Browse Events</h3>
 
-        {/* Search and Filters */}
-        <div className="filter-controls" style={{ marginBottom: 20 }}>
+        {/* Segment deck */}
+        <div style={{ position: "relative", margin: "10px 0 18px 0", height: 120 }}>
+          {/* Left chevron */}
+          <button
+            aria-label="Previous segment"
+            onClick={goLeft}
+            className="btn btn-secondary"
+            style={{
+              position: "absolute",
+              left: 8,
+              top: "50%",
+              transform: "translateY(-50%)",
+              zIndex: 5,
+            }}
+          >
+            ‹
+          </button>
+
+          {/* Past (left) */}
+          <button
+            onClick={() => setActiveSeg("Past")}
+            className="card"
+            style={{
+              position: "absolute",
+              left: "6%",
+              top: 18,
+              width: "30%",
+              height: 84,
+              borderRadius: 14,
+              border: "1px solid #e9ecef",
+              background:
+                activeSeg === "Past" ? "#ffffff" : "linear-gradient(0deg, #f5f5f5, #fafafa)",
+              transform: activeSeg === "Past" ? "scale(1.02)" : "scale(0.96) rotate(-1deg)",
+              boxShadow:
+                activeSeg === "Past"
+                  ? "0 12px 28px rgba(0,0,0,0.15)"
+                  : "0 6px 16px rgba(0,0,0,0.08)",
+              transition: "all 0.25s ease",
+              cursor: "pointer",
+              zIndex: activeSeg === "Past" ? 4 : 2,
+              padding: "12px 14px",
+            }}
+          >
+            <div style={{ fontWeight: 700, color: "#6c757d" }}>Past</div>
+            <div style={{ fontSize: 12, color: "#6c757d" }}>{counts.Past} events</div>
+            <div style={{ fontSize: 11, color: "#adb5bd", marginTop: 6 }}>
+              Completed & archived
+            </div>
+          </button>
+
+          {/* Current (center) */}
+          <button
+            onClick={() => setActiveSeg("Current")}
+            className="card"
+            style={{
+              position: "absolute",
+              left: "50%",
+              top: 8,
+              width: "36%",
+              height: 100,
+              borderRadius: 16,
+              border: "1px solid #e9ecef",
+              background:
+                activeSeg === "Current"
+                  ? "#ffffff"
+                  : "linear-gradient(0deg, #f7f7f7, #fcfcfc)",
+              transform: activeSeg === "Current" ? "translateX(-50%) scale(1.06)" : "translateX(-50%) scale(0.98)",
+              boxShadow:
+                activeSeg === "Current"
+                  ? "0 16px 32px rgba(0,0,0,0.18)"
+                  : "0 8px 18px rgba(0,0,0,0.1)",
+              transition: "all 0.25s ease",
+              cursor: "pointer",
+              zIndex: activeSeg === "Current" ? 5 : 3,
+              padding: "16px 18px",
+            }}
+          >
+            <div style={{ fontWeight: 800, color: "#2c3e50" }}>Current</div>
+            <div style={{ fontSize: 13, color: "#2c3e50" }}>{counts.Current} events</div>
+            <div style={{ fontSize: 12, color: "#6c757d", marginTop: 6 }}>
+              Happening today
+            </div>
+          </button>
+
+          {/* Upcoming (right) */}
+          <button
+            onClick={() => setActiveSeg("Upcoming")}
+            className="card"
+            style={{
+              position: "absolute",
+              right: "6%",
+              top: 18,
+              width: "30%",
+              height: 84,
+              borderRadius: 14,
+              border: "1px solid #e9ecef",
+              background:
+                activeSeg === "Upcoming" ? "#ffffff" : "linear-gradient(0deg, #f5f5f5, #fafafa)",
+              transform: activeSeg === "Upcoming" ? "scale(1.02)" : "scale(0.96) rotate(1deg)",
+              boxShadow:
+                activeSeg === "Upcoming"
+                  ? "0 12px 28px rgba(0,0,0,0.15)"
+                  : "0 6px 16px rgba(0,0,0,0.08)",
+              transition: "all 0.25s ease",
+              cursor: "pointer",
+              zIndex: activeSeg === "Upcoming" ? 4 : 2,
+              padding: "12px 14px",
+            }}
+          >
+            <div style={{ fontWeight: 700, color: "#0d6efd" }}>Upcoming</div>
+            <div style={{ fontSize: 12, color: "#0d6efd" }}>{counts.Upcoming} events</div>
+            <div style={{ fontSize: 11, color: "#6ea8fe", marginTop: 6 }}>
+              Registered & future
+            </div>
+          </button>
+
+          {/* Right chevron */}
+          <button
+            aria-label="Next segment"
+            onClick={goRight}
+            className="btn btn-secondary"
+            style={{
+              position: "absolute",
+              right: 8,
+              top: "50%",
+              transform: "translateY(-50%)",
+              zIndex: 5,
+            }}
+          >
+            ›
+          </button>
+        </div>
+
+        {/* Search and Filters (unchanged) */}
+        <div className="filter-controls" style={{ margin: "8px 0 20px 0", display: "flex", gap: 10, flexWrap: "wrap" }}>
           <input
             type="text"
             placeholder="Search events..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="form-control"
-            style={{ flex: 1, minWidth: "250px" }}
+            style={{ flex: 1, minWidth: 250 }}
           />
           <select
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             className="form-control"
-            style={{ minWidth: "150px" }}
+            style={{ minWidth: 150 }}
           >
             <option value="All">All Categories</option>
             <option value="Technology">Technology</option>
             <option value="Entertainment">Entertainment</option>
             <option value="Business">Business</option>
             <option value="Sports">Sports</option>
+            <option value="General">General</option>
           </select>
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value)}
             className="form-control"
-            style={{ minWidth: "150px" }}
+            style={{ minWidth: 150 }}
           >
             <option value="date">Sort by Date</option>
             <option value="price">Sort by Price</option>
@@ -338,57 +368,89 @@ const filteredMyActivities = myActivities.filter((event) => {
           </select>
         </div>
 
-        {/* Events Grid */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
-            gap: "1.5rem",
-            width: "100%",
-          }}
-        >
-          {filteredEvents.map((event) => (
-            <div
-              key={event.id}
-              className="card"
-              style={{
-                border: "1px solid #e9ecef",
-                borderRadius: 12,
-                padding: 16,
-                background: "#f9f9f9",
-                transition: "all 0.3s ease",
-                cursor: "pointer",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = "translateY(-4px)";
-                e.currentTarget.style.boxShadow = "0 8px 25px rgba(0,0,0,0.15)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = "translateY(0)";
-                e.currentTarget.style.boxShadow = "0 8px 32px rgba(0, 0, 0, 0.1)";
-              }}
-            >
-              <h4 style={{ margin: "0 0 12px 0", color: "#2c3e50", fontSize: "1.2rem" }}>
-                {event.name}
-              </h4>
-              <div style={{ marginBottom: 16, fontSize: "0.9rem", color: "#495057" }}>
-                <p style={{ margin: "4px 0" }}>
-                  <strong>Date:</strong> {event.date} at {event.time}
-                </p>
-                <p style={{ margin: "4px 0" }}>
-                  <strong>Location:</strong> {event.location}
-                </p>
-                <p style={{ margin: "4px 0" }}>
-                  <strong>Price:</strong>{" "}
-                  <span style={{ color: "#28a745", fontWeight: 600 }}>${event.price}</span>
-                </p>
-                <p style={{ margin: "4px 0" }}>
-                  <strong>Category:</strong> {event.category}
-                </p>
-                <p style={{ margin: "4px 0" }}>
-                  <strong>Attendees:</strong> {event.attendees}/{event.maxAttendees}
-                </p>
-              </div>
+        {/* Section heading */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+          <span
+            className="badge"
+            style={{
+              background:
+                activeSeg === "Past"
+                  ? "#6c757d"
+                  : activeSeg === "Current"
+                  ? "#198754"
+                  : "#0d6efd",
+              color: "white",
+              borderRadius: 12,
+              padding: "6px 10px",
+              fontWeight: 700,
+            }}
+          >
+            {activeSeg}
+          </span>
+          <span style={{ color: "#6c757d", fontSize: 13 }}>
+            {counts[activeSeg]} result{counts[activeSeg] === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {/* Events Grid (for the active segment) */}
+        {activeList.length === 0 ? (
+          <div style={{ textAlign: "center", padding: "2.2rem", color: "#6c757d" }}>
+            <p style={{ fontSize: "1.05rem", margin: 0 }}>
+              No {activeSeg.toLowerCase()} events match your filters.
+            </p>
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+              gap: "1.5rem",
+              width: "100%",
+            }}
+          >
+            {activeList.map((event) => (
+              <div
+                key={event.id}
+                className="card"
+                style={{
+                  border: "1px solid #e9ecef",
+                  borderRadius: 12,
+                  padding: 16,
+                  background: "#f9f9f9",
+                  transition: "all 0.3s ease",
+                  cursor: "pointer",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = "translateY(-4px)";
+                  e.currentTarget.style.boxShadow = "0 8px 25px rgba(0,0,0,0.15)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = "translateY(0)";
+                  e.currentTarget.style.boxShadow = "0 8px 32px rgba(0, 0, 0, 0.1)";
+                }}
+              >
+                <h4 style={{ margin: "0 0 12px 0", color: "#2c3e50", fontSize: "1.2rem" }}>
+                  {event.name}
+                </h4>
+                <div style={{ marginBottom: 16, fontSize: "0.9rem", color: "#495057" }}>
+                  <p style={{ margin: "4px 0" }}>
+                    <strong>Date:</strong> {event.date} {event.time && `at ${event.time}`}
+                  </p>
+                  <p style={{ margin: "4px 0" }}>
+                    <strong>Location:</strong> {event.location}
+                  </p>
+                  <p style={{ margin: "4px 0" }}>
+                    <strong>Price:</strong>{" "}
+                    <span style={{ fontWeight: 600 }}>${event.price}</span>
+                  </p>
+                  <p style={{ margin: "4px 0" }}>
+                    <strong>Category:</strong> {event.category}
+                  </p>
+                  <p style={{ margin: "4px 0" }}>
+                    <strong>Attendees:</strong> {event.attendees}/{event.maxAttendees}
+                  </p>
+                </div>
+
                 <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                   <button
                     onClick={(e) => {
@@ -406,7 +468,9 @@ const filteredMyActivities = myActivities.filter((event) => {
                       e.stopPropagation();
                       handleJoinEvent(event);
                     }}
-                    disabled={event.attendees >= event.maxAttendees || registeredIds.has(event.id)}
+                    disabled={
+                      event.attendees >= event.maxAttendees || registeredIds.has(event.id)
+                    }
                     className={`btn ${
                       event.attendees >= event.maxAttendees || registeredIds.has(event.id)
                         ? "btn-secondary"
@@ -421,125 +485,8 @@ const filteredMyActivities = myActivities.filter((event) => {
                       : "Join Event"}
                   </button>
                 </div>
-
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* My Activities Section */}
-      <div className="card" style={{ width: "100%", padding: "1.5rem" }}>
-        <div
-          style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 20 }}
-        >
-          <h3 style={{ margin: 0, color: "#2c3e50" }}>My Activities</h3>
-          <select
-            value={activityFilter}
-            onChange={(e) => setActivityFilter(e.target.value)}
-            className="form-control"
-            style={{ maxWidth: "200px" }}
-          >
-            <option value="All">All Events</option>
-            <option value="Previous">Previous</option>
-            <option value="Current">Current</option>
-            <option value="Upcoming">Upcoming</option>
-          </select>
-        </div>
-
-        {filteredMyActivities.length === 0 ? (
-          <div style={{ textAlign: "center", padding: "3rem", color: "#6c757d" }}>
-            <p style={{ fontSize: "1.1rem", margin: 0 }}>No events found for the selected filter.</p>
-            <p style={{ fontSize: "0.9rem", margin: "8px 0 0 0" }}>Browse events above to join some!</p>
-          </div>
-        ) : (
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
-              gap: "1.5rem",
-              width: "100%",
-            }}
-          >
-            {filteredMyActivities.map((event) => {
-              const eventDate = new Date(event.date);
-              const today = new Date();
-              const isPast = eventDate < today;
-
-              return (
-                <div
-                  key={event.id}
-                  className="card"
-                  style={{
-                    border: "1px solid #e9ecef",
-                    borderRadius: 12,
-                    padding: 16,
-                    background: isPast ? "#f8f9fa" : "#ffffff",
-                    position: "relative",
-                  }}
-                >
-                  {isPast && (
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: 8,
-                        right: 8,
-                        padding: "2px 8px",
-                        background: "#6c757d",
-                        color: "white",
-                        borderRadius: "12px",
-                        fontSize: "0.7rem",
-                        fontWeight: 600,
-                      }}
-                    >
-                      COMPLETED
-                    </div>
-                  )}
-                  <h4 style={{ margin: "0 0 12px 0", color: "#2c3e50", fontSize: "1.1rem" }}>
-                    {event.name}
-                  </h4>
-                  <div style={{ marginBottom: 16, fontSize: "0.9rem", color: "#495057" }}>
-                    <p style={{ margin: "4px 0" }}>
-                      <strong>Date:</strong> {event.date} at {event.time}
-                    </p>
-                    <p style={{ margin: "4px 0" }}>
-                      <strong>Location:</strong> {event.location}
-                    </p>
-                    <p style={{ margin: "4px 0" }}>
-                      <strong>Status:</strong> {event.status}
-                    </p>
-                    {event.rating && (
-                      <p style={{ margin: "4px 0" }}>
-                        <strong>Your Rating:</strong>
-                        <span style={{ color: "#ffc107", marginLeft: 4 }}>
-                          {"★".repeat(event.rating)}
-                          {"☆".repeat(5 - event.rating)}
-                        </span>
-                      </p>
-                    )}
-                  </div>
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                    {!isPast && (
-                      <button
-                        onClick={() => handleCancelRegistration(event.id)}
-                        className="btn btn-danger"
-                        style={{ padding: "6px 12px", fontSize: "0.8rem", flex: 1 }}
-                      >
-                        Cancel Registration
-                      </button>
-                    )}
-                    {isPast && !event.rating && (
-                      <button
-                        onClick={() => setShowRating(event.id)}
-                        className="btn btn-warning"
-                        style={{ padding: "6px 12px", fontSize: "0.8rem", flex: 1 }}
-                      >
-                        Rate Event
-                      </button>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+              </div>
+            ))}
           </div>
         )}
       </div>
@@ -557,7 +504,8 @@ const filteredMyActivities = myActivities.filter((event) => {
             <div>
               <div style={{ marginBottom: "1rem" }}>
                 <p>
-                  <strong>Date:</strong> {selectedEvent.date} at {selectedEvent.time}
+                  <strong>Date:</strong> {selectedEvent.date}{" "}
+                  {selectedEvent.time && `at ${selectedEvent.time}`}
                 </p>
                 <p>
                   <strong>Location:</strong> {selectedEvent.location}
@@ -577,7 +525,9 @@ const filteredMyActivities = myActivities.filter((event) => {
               </div>
               <div>
                 <strong>Description:</strong>
-                <p style={{ marginTop: "0.5rem", color: "#495057" }}>{selectedEvent.description}</p>
+                <p style={{ marginTop: "0.5rem", color: "#495057" }}>
+                  {selectedEvent.description}
+                </p>
               </div>
             </div>
           </div>
@@ -616,69 +566,6 @@ const filteredMyActivities = myActivities.filter((event) => {
                 </button>
                 <button className="btn btn-success" onClick={() => handlePayment(showPayment)}>
                   Pay Now
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Rating Modal */}
-      {showRating && (
-        <div
-          className="modal-overlay"
-          onClick={() => {
-            setShowRating(null);
-            setRating(0);
-          }}
-        >
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">
-              <h4>Rate This Event</h4>
-              <button
-                className="modal-close"
-                onClick={() => {
-                  setShowRating(null);
-                  setRating(0);
-                }}
-              >
-                ×
-              </button>
-            </div>
-            <div style={{ textAlign: "center" }}>
-              <div style={{ margin: "20px 0" }}>
-                {[1, 2, 3, 4, 5].map((star) => (
-                  <span
-                    key={star}
-                    style={{
-                      fontSize: "2rem",
-                      cursor: "pointer",
-                      color: star <= rating ? "#ffc107" : "#ddd",
-                      transition: "color 0.2s ease",
-                    }}
-                    onClick={() => setRating(star)}
-                  >
-                    ★
-                  </span>
-                ))}
-              </div>
-
-              <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
-                <button
-                  className="btn btn-secondary"
-                  onClick={() => {
-                    setShowRating(null);
-                    setRating(0);
-                  }}
-                >
-                  Cancel
-                </button>
-                <button
-                  className="btn btn-success"
-                  disabled={rating === 0}
-                  onClick={() => handleRateEvent(showRating, rating)}
-                >
-                  Submit Rating
                 </button>
               </div>
             </div>

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/AdminController/AdminDashboardController.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/AdminController/AdminDashboardController.java
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.util.Map;
 
+import org.springframework.format.annotation.DateTimeFormat;
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(AdminControllerConstants.ADMIN_BASE_URL)
@@ -66,4 +69,17 @@ public class AdminDashboardController {
                                                       @RequestParam LocalDate end) {
         return adminService.getDailyCancellationCount(start, end);
     }
+
+    @GetMapping("/daily-bookings-breakdown")
+    public ResponseEntity<Map<String, Long>> dailyBookingsBreakdown(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(statistics.dailyBookingsBreakdown(date));
+    }
+
+    @GetMapping("/daily-cancellations-breakdown")
+    public ResponseEntity<Map<String, Long>> dailyCancellationsBreakdown(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(statistics.dailyCancellationsBreakdown(date));
+    }
+
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/AdminController/AdminDashboardController.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/AdminController/AdminDashboardController.java
@@ -3,25 +3,21 @@ package com.example.cdr.eventsmanagementsystem.Controller.AdminController;
 import com.example.cdr.eventsmanagementsystem.Constants.ControllerConstants.AdminControllerConstants;
 import com.example.cdr.eventsmanagementsystem.Constants.ControllerConstants.RoleConstants;
 import com.example.cdr.eventsmanagementsystem.DTO.Admin.DashboardStatisticsDto;
-import com.example.cdr.eventsmanagementsystem.Service.User.AdminService;
 import com.example.cdr.eventsmanagementsystem.Keycloak.KeycloakAdminService;
+import com.example.cdr.eventsmanagementsystem.Service.User.AdminService;
+import com.example.cdr.eventsmanagementsystem.Service.User.StatisticsManagement;  // << add this
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.time.LocalDate;
 import java.util.Map;
-/**
-
- * REST controller for admin dashboard operations.
- * Provides endpoints to retrieve dashboard statistics, event type distribution,
- * daily bookings, and daily cancellations.
- */
-import org.springframework.http.ResponseEntity;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,30 +25,24 @@ import org.springframework.http.ResponseEntity;
 @PreAuthorize("hasRole('" + RoleConstants.ADMIN_ROLE + "')")
 @Tag(name = "Admin - Dashboard", description = "Admin dashboard & statistics APIs")
 public class AdminDashboardController {
+
     private final AdminService adminService;
     private final KeycloakAdminService keycloakAdminService;
+    private final StatisticsManagement statistics;   // << inject it
 
     @Operation(summary = "Get dashboard statistics", description = "Retrieves statistics for the dashboard")
     @GetMapping(AdminControllerConstants.ADMIN_DASHBOARD_URL)
     public ResponseEntity<DashboardStatisticsDto> dashboard() {
-    DashboardStatisticsDto dto = new DashboardStatisticsDto();
+        // Start with DB-derived stats (totals, utilization, revenue)
+        DashboardStatisticsDto dto = statistics.getDashboardStatistics();
 
-        // ---- USERS (from Keycloak) ----
+        // Overwrite the user counts with Keycloak (if you prefer KC as source of truth)
         Map<String, Long> c = keycloakAdminService.countUsersByRole();
         dto.setNumAdmins(c.getOrDefault("admins", 0L));
         dto.setNumOrganizers(c.getOrDefault("organizers", 0L));
         dto.setNumAttendees(c.getOrDefault("attendees", 0L));
         dto.setNumServiceProviders(c.getOrDefault("service_providers", 0L));
         dto.setNumVenueProviders(c.getOrDefault("venue_providers", 0L));
-
-        // ---- EVENTS (keep your existing queries if any) ----
-        // dto.setTotalUpcoming(...);
-        // dto.setTotalOngoing(...);
-        // dto.setTotalCompleted(...);
-        // dto.setTotalCancelled(...);
-
-        // dto.setVenueUtilizationRate(...);
-        // dto.setServiceProviderUtilizationRate(...);
 
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/DashboardStatisticsDto.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/DashboardStatisticsDto.java
@@ -1,6 +1,7 @@
 package com.example.cdr.eventsmanagementsystem.DTO.Admin;
 
 import lombok.Data;
+import java.util.List;
 
 @Data
 public class DashboardStatisticsDto {
@@ -17,6 +18,12 @@ public class DashboardStatisticsDto {
 
     private double venueUtilizationRate;
     private double serviceProviderUtilizationRate;
+    private List<UiRevenue> revenueByOrganizer;
+
+    private long venueActiveNow;
+    private long venueTotal;
+    private long serviceProvidersActiveNow;
+    private long serviceProvidersTotal;
 }
 
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
@@ -1,4 +1,3 @@
-// src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
 package com.example.cdr.eventsmanagementsystem.DTO.Admin;
 
 import java.math.BigDecimal;
@@ -8,6 +7,6 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class UiRevenue {
-    private String name;         // organizer name
+    private String organizerName;
     private BigDecimal revenue;  // net revenue (BigDecimal serialized as number)
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
@@ -1,0 +1,13 @@
+// src/main/java/com/example/cdr/eventsmanagementsystem/DTO/Admin/UiRevenue.java
+package com.example.cdr.eventsmanagementsystem.DTO.Admin;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UiRevenue {
+    private String name;         // organizer name
+    private BigDecimal revenue;  // net revenue (BigDecimal serialized as number)
+}

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
@@ -12,8 +12,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
-
-import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus;
@@ -24,14 +22,15 @@ import java.time.ZonedDateTime;
 
 @Repository
 public interface EventBookingRepository extends JpaRepository<EventBooking, Long> {
-    @Query("select function('date', b.createdAt) as date, count(b) as count from EventBooking b "+
-            "where function('date', b.createdAt) >= :start and function('date', b.createdAt) <= :end "+
-            "group by function('date', b.createdAt) order by function('date', b.createdAt)")
+
+    @Query("select function('date', b.createdAt) as date, count(b) as count from EventBooking b "
+            + "where function('date', b.createdAt) >= :start and function('date', b.createdAt) <= :end "
+            + "group by function('date', b.createdAt) order by function('date', b.createdAt)")
     List<LocalDateCount> countDailyBookingsBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
 
-    @Query("select function('date', b.cancelledAt) as date, count(b) as count from EventBooking b "+
-            "where b.cancelledAt is not null and function('date', b.cancelledAt) >= :start and function('date', b.cancelledAt) <= :end "+
-            "group by function('date', b.cancelledAt) order by function('date', b.cancelledAt)")
+    @Query("select function('date', b.cancelledAt) as date, count(b) as count from EventBooking b "
+            + "where b.cancelledAt is not null and function('date', b.cancelledAt) >= :start and function('date', b.cancelledAt) <= :end "
+            + "group by function('date', b.cancelledAt) order by function('date', b.cancelledAt)")
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
 
     @Query("""
@@ -41,12 +40,11 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
         and b.cancelledAt >= :start
         and b.cancelledAt <  :end
         """)
-        long countCancelledBetween(@Param("status") BookingStatus status,
-                                @Param("start") LocalDateTime start,
-                                @Param("end") LocalDateTime end);
+    long countCancelledBetween(@Param("status") BookingStatus status,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 
-
-    List <EventBooking> findByStatusAndStartTimeBetween(
+    List<EventBooking> findByStatusAndStartTimeBetween(
             BookingStatus status,
             LocalDateTime start,
             LocalDateTime end
@@ -59,18 +57,17 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
             Pageable pageable
     );
 
-        @Query("""
+    @Query("""
         select count(b) from EventBooking b
         where b.createdAt >= :start
         and b.createdAt <  :end
         and b.status in :statuses
         """)
-        long countCreatedBetweenForStatuses(
-        @Param("start") java.time.LocalDateTime start,
-        @Param("end")   java.time.LocalDateTime end,
-        @Param("statuses") java.util.Collection<com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus> statuses
-        );
-
+    long countCreatedBetweenForStatuses(
+            @Param("start") java.time.LocalDateTime start,
+            @Param("end") java.time.LocalDateTime end,
+            @Param("statuses") java.util.Collection<com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus> statuses
+    );
 
     EventBooking findByStripeSessionId(String sessionId);
 
@@ -80,7 +77,7 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
 
     @Query("select eb from EventBooking eb where eb.eventId = :eventId order by eb.createdAt desc")
     Page<EventBooking> findByEventIdOrderByCreatedAtDesc(Long eventId, Pageable pageable);
-    
+
     Page<EventBooking> findByCreatedBy(String createdBy, Pageable pageable);
 
     @Query("""
@@ -90,10 +87,10 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
         GROUP BY function('date', b.createdAt)
         ORDER BY function('date', b.createdAt)
         """)
-        List<LocalDateCount> countDailyBookingsBetween(@Param("start") LocalDateTime start,
-                                                @Param("end") LocalDateTime end);
+    List<LocalDateCount> countDailyBookingsBetween(@Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 
-        @Query("""
+    @Query("""
         SELECT function('date', COALESCE(b.cancelledAt, b.updatedAt)) AS date, COUNT(b) AS count
         FROM EventBooking b
         WHERE (b.status = com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.CANCELLED
@@ -102,29 +99,29 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
         GROUP BY function('date', COALESCE(b.cancelledAt, b.updatedAt))
         ORDER BY function('date', COALESCE(b.cancelledAt, b.updatedAt))
         """)
-        List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
-                                                        @Param("end") LocalDateTime end);
+    List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 
-
-
-        @Query("""
+    @Query("""
         select count(b) from EventBooking b
         where b.createdAt >= :start and b.createdAt < :end and b.status = :status
         """)
-        long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
-                                        @Param("start") java.time.LocalDateTime start,
-                                        @Param("end") java.time.LocalDateTime end);
+    long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
+            @Param("start") java.time.LocalDateTime start,
+            @Param("end") java.time.LocalDateTime end);
 
-        interface OrganizerRevenueRow {
-                Long getOrganizerId();
-                String getFirstName();
-                String getLastName();
-                java.math.BigDecimal getRevenue();
-        }
+    interface OrganizerRevenueRow {
 
+        Long getOrganizerId();
 
+        String getFirstName();
 
-        @Query("""
+        String getLastName();
+
+        java.math.BigDecimal getRevenue();
+    }
+
+    @Query("""
                 select e.organizer.id as organizerId,
                 e.organizer.firstName as firstName,
                 e.organizer.lastName  as lastName,
@@ -144,8 +141,5 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
                 group by e.organizer.id, e.organizer.firstName, e.organizer.lastName
                 order by revenue desc
         """)
-        java.util.List<OrganizerRevenueRow> sumRevenueByOrganizer();
+    java.util.List<OrganizerRevenueRow> sumRevenueByOrganizer();
 }
-
-
-

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
@@ -77,12 +77,24 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
         List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
 
+
+
+        @Query("""
+        select count(b) from EventBooking b
+        where b.createdAt >= :start and b.createdAt < :end and b.status = :status
+        """)
+        long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
+                                        @Param("start") java.time.LocalDateTime start,
+                                        @Param("end") java.time.LocalDateTime end);
+
         interface OrganizerRevenueRow {
                 Long getOrganizerId();
                 String getFirstName();
                 String getLastName();
                 java.math.BigDecimal getRevenue();
         }
+
+
 
         @Query("""
                 select e.organizer.id as organizerId,

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventBookingRepository.java
@@ -18,6 +18,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus;
 import com.example.cdr.eventsmanagementsystem.Model.Booking.EventBooking;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Repository
 public interface EventBookingRepository extends JpaRepository<EventBooking, Long> {
@@ -31,6 +34,18 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
             "group by function('date', b.cancelledAt) order by function('date', b.cancelledAt)")
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
 
+    @Query("""
+        select count(b) from EventBooking b
+        where b.status = :status
+        and b.cancelledAt is not null
+        and b.cancelledAt >= :start
+        and b.cancelledAt <  :end
+        """)
+        long countCancelledBetween(@Param("status") BookingStatus status,
+                                @Param("start") LocalDateTime start,
+                                @Param("end") LocalDateTime end);
+
+
     List <EventBooking> findByStatusAndStartTimeBetween(
             BookingStatus status,
             LocalDateTime start,
@@ -43,6 +58,19 @@ public interface EventBookingRepository extends JpaRepository<EventBooking, Long
             LocalDateTime end,
             Pageable pageable
     );
+
+        @Query("""
+        select count(b) from EventBooking b
+        where b.createdAt >= :start
+        and b.createdAt <  :end
+        and b.status in :statuses
+        """)
+        long countCreatedBetweenForStatuses(
+        @Param("start") java.time.LocalDateTime start,
+        @Param("end")   java.time.LocalDateTime end,
+        @Param("statuses") java.util.Collection<com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus> statuses
+        );
+
 
     EventBooking findByStripeSessionId(String sessionId);
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventRepository.java
@@ -31,7 +31,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     long countByStatus(EventStatus status);
 
-    // ADD this query method to support getFlaggedEvents():
     Page<Event> findByFlaggedTrue(Pageable pageable);
 
     @Query("select e.type as type, count(e) as count from Event e group by e.type")

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
@@ -12,6 +12,7 @@ import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
 
 
 import com.example.cdr.eventsmanagementsystem.Model.Booking.ServiceBooking;
+import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus;
 
 @Repository
 public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, Long> {
@@ -46,6 +47,15 @@ public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, 
     """)
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
+
+    @Query("""
+    select count(b) from ServiceBooking b
+    where b.createdAt >= :start and b.createdAt < :end and b.status = :status
+    """)
+    long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
+                                        @Param("start") java.time.LocalDateTime start,
+                                      @Param("end") java.time.LocalDateTime end);
+
     @Query("""
       select count(distinct s.serviceProvider.id)
       from ServiceBooking sb

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
@@ -46,5 +46,18 @@ public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, 
     """)
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
+    @Query("""
+      select count(distinct s.serviceProvider.id)
+      from ServiceBooking sb
+      join Services s on s.id = sb.serviceId
+      where sb.status in (
+        com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.BOOKED,
+        com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.ACCEPTED
+      )
+      and sb.startTime <= :now and sb.endTime >= :now
+    """)
+    long countDistinctActiveServiceProvidersAt(@Param("now") java.time.LocalDateTime now);
+
+
 
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
@@ -13,6 +13,9 @@ import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
 
 import com.example.cdr.eventsmanagementsystem.Model.Booking.ServiceBooking;
 import com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Repository
 public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, Long> {
@@ -37,6 +40,16 @@ public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, 
                                                   @Param("end") LocalDateTime end);
 
     @Query("""
+    select count(b) from EventBooking b
+    where b.status = :status
+    and b.cancelledAt is not null
+    and b.cancelledAt >= :start
+    and b.cancelledAt <  :end
+    """)
+    long countCancelledBetween(@Param("status") BookingStatus status,
+                            @Param("start") LocalDateTime start,
+                            @Param("end") LocalDateTime end);                                              
+    @Query("""
       SELECT function('date', COALESCE(b.cancelledAt, b.updatedAt)) AS date, COUNT(b) AS count
       FROM ServiceBooking b
       WHERE (b.status = com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.CANCELLED
@@ -54,8 +67,21 @@ public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, 
     """)
     long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
                                         @Param("start") java.time.LocalDateTime start,
-                                      @Param("end") java.time.LocalDateTime end);
+                
+                                        @Param("end") java.time.LocalDateTime end);
 
+    @Query("""
+      select count(b) from ServiceBooking b
+      where b.createdAt >= :start
+        and b.createdAt <  :end
+        and b.status in :statuses
+    """)
+    long countCreatedBetweenForStatuses(
+        @Param("start") java.time.LocalDateTime start,
+        @Param("end")   java.time.LocalDateTime end,
+        @Param("statuses") java.util.Collection<com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus> statuses
+    );
+                                        
     @Query("""
       select count(distinct s.serviceProvider.id)
       from ServiceBooking sb

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
 
+
 @Repository
 public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long> {
     VenueBooking findByStripeSessionId(String sessionId);
@@ -47,6 +48,14 @@ public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long
     """)
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
+
+    @Query("""
+      select count(b) from VenueBooking b
+      where b.createdAt >= :start and b.createdAt < :end and b.status = :status
+    """)
+    long countByStatusAndCreatedAtBetween(@Param("status") BookingStatus status,
+                                          @Param("start") java.time.LocalDateTime start,
+                                          @Param("end") java.time.LocalDateTime end);
 
     @Query("""
       select count(distinct vb.venueId)

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import com.example.cdr.eventsmanagementsystem.DTO.projections.LocalDateCount;
-
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Repository
 public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long> {
@@ -49,6 +51,20 @@ public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
 
+
+    @Query("""
+    select count(b) from EventBooking b
+    where b.status = :status
+    and b.cancelledAt is not null
+    and b.cancelledAt >= :start
+    and b.cancelledAt <  :end
+    """)
+    long countCancelledBetween(@Param("status") BookingStatus status,
+                            @Param("start") LocalDateTime start,
+                            @Param("end") LocalDateTime end);
+
+                            
+
     @Query("""
       select count(b) from VenueBooking b
       where b.createdAt >= :start and b.createdAt < :end and b.status = :status
@@ -57,6 +73,18 @@ public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long
                                           @Param("start") java.time.LocalDateTime start,
                                           @Param("end") java.time.LocalDateTime end);
 
+    @Query("""
+      select count(b) from VenueBooking b
+      where b.createdAt >= :start
+        and b.createdAt <  :end
+        and b.status in :statuses
+    """)
+    long countCreatedBetweenForStatuses(
+        @Param("start") java.time.LocalDateTime start,
+        @Param("end")   java.time.LocalDateTime end,
+        @Param("statuses") java.util.Collection<com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus> statuses
+    );
+                                      
     @Query("""
       select count(distinct vb.venueId)
       from VenueBooking vb

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
@@ -48,4 +48,21 @@ public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long
     List<LocalDateCount> countDailyCancellationsBetween(@Param("start") LocalDateTime start,
                                                         @Param("end") LocalDateTime end);
 
+    @Query("""
+      select count(distinct vb.venueId)
+      from VenueBooking vb
+      where (vb.paymentStatus in (
+              com.example.cdr.eventsmanagementsystem.Model.Booking.PaymentStatus.CAPTURED,
+              com.example.cdr.eventsmanagementsystem.Model.Booking.PaymentStatus.PARTIALLY_REFUNDED,
+              com.example.cdr.eventsmanagementsystem.Model.Booking.PaymentStatus.AUTHORIZED
+            )
+            or vb.status in (
+              com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.BOOKED,
+              com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.ACCEPTED
+            ))
+        and vb.status <> com.example.cdr.eventsmanagementsystem.Model.Booking.BookingStatus.CANCELLED
+        and vb.startTime <= :now and vb.endTime >= :now
+    """)
+    long countDistinctActiveVenueIdsAt(@Param("now") LocalDateTime now);
+
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/EventBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/EventBookingService.java
@@ -42,6 +42,9 @@ import com.stripe.model.Customer;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Slf4j
 @Service
@@ -175,12 +178,15 @@ public class EventBookingService {
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
 
+        ZoneId utc = ZoneOffset.UTC;
         booking.setStatus(BookingStatus.CANCELLED);
         booking.setCancellationReason(request.getReason());
-        booking.setCancelledAt(LocalDateTime.now());
+        booking.setCancelledAt(LocalDateTime.now(utc));
         booking.setCancelledBy(currentUserId);
 
         bookingRepository.save(booking);
         eventPublisher.publishEvent(new EventBookingCancelled(booking, request.getReason()));
     }
+
+
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/ServiceBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/ServiceBookingService.java
@@ -43,6 +43,9 @@ import com.stripe.model.Customer;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Slf4j
 @Service
@@ -170,13 +173,15 @@ public class ServiceBookingService {
             stripeService.createRefund(booking.getStripePaymentId(), null, stripeReason);
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
-
+        ZoneId utc = ZoneOffset.UTC;
         booking.setStatus(BookingStatus.CANCELLED);
         booking.setCancellationReason(request.getReason());
-        booking.setCancelledAt(LocalDateTime.now());
+        booking.setCancelledAt(LocalDateTime.now(utc));
         booking.setCancelledBy(currentUserId);
 
         bookingRepository.save(booking);
         eventPublisher.publishEvent(new ServiceBookingCancelled(booking, request.getReason()));
     }
+
+    
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/VenueBookingService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Booking/VenueBookingService.java
@@ -43,6 +43,9 @@ import com.stripe.model.Customer;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Slf4j
 @Service
@@ -171,9 +174,10 @@ public class VenueBookingService {
             booking.setRefundProcessedAt(LocalDateTime.now());
         }
 
+        ZoneId utc = ZoneOffset.UTC;
         booking.setStatus(BookingStatus.CANCELLED);
         booking.setCancellationReason(request.getReason());
-        booking.setCancelledAt(LocalDateTime.now());
+        booking.setCancelledAt(LocalDateTime.now(utc));
         booking.setCancelledBy(currentUserId);
 
         bookingRepository.save(booking);

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
@@ -35,6 +35,7 @@ import com.example.cdr.eventsmanagementsystem.Repository.VenueRepository;
 import com.example.cdr.eventsmanagementsystem.Service.Payment.StripeService;
 import com.example.cdr.eventsmanagementsystem.DTO.Admin.UiRevenue;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
@@ -34,7 +34,7 @@ import com.example.cdr.eventsmanagementsystem.Repository.VenueBookingRepository;
 import com.example.cdr.eventsmanagementsystem.Repository.VenueRepository;
 import com.example.cdr.eventsmanagementsystem.Service.Payment.StripeService;
 import com.example.cdr.eventsmanagementsystem.DTO.Admin.UiRevenue;
-
+import lombok.AllArgsConstructor;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/User/StatisticsManagement.java
@@ -27,7 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
-
+import java.time.*;
 /**
  * Service class for administrative operations related statistics.
  * Handles reporting statistics.
@@ -160,6 +160,38 @@ public class StatisticsManagement {
 
         return result;
     }
+
+
+    public Map<String, Long> dailyBookingsBreakdown(LocalDate day) {
+        LocalDateTime start = day.atStartOfDay();
+        LocalDateTime end = day.plusDays(1).atStartOfDay();
+
+        long events   = eventBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.BOOKED, start, end);
+        long services = serviceBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.BOOKED, start, end);
+        long venue    = venueBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.BOOKED, start, end);
+        long total    = events + services + venue;
+
+        return Map.of("venue", venue, "services", services, "events", events, "total", total);
+    }
+
+    public Map<String, Long> dailyCancellationsBreakdown(LocalDate day) {
+        LocalDateTime start = day.atStartOfDay();
+        LocalDateTime end = day.plusDays(1).atStartOfDay();
+
+        long events   = eventBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.CANCELLED, start, end);
+        long services = serviceBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.CANCELLED, start, end);
+        long venue    = venueBookingRepository
+            .countByStatusAndCreatedAtBetween(BookingStatus.CANCELLED, start, end);
+        long total    = events + services + venue;
+
+        return Map.of("venue", venue, "services", services, "events", events, "total", total);
+    }
+
 
     public Page<OrganizerRevenueDto> getRevenuePerOrganizer(LocalDate startDate, LocalDate endDate, Pageable pageable) {
         var rows = eventBookingRepository.sumRevenueByOrganizer(); // projection: organizerId, revenue


### PR DESCRIPTION
Fixes #72
Fixes #76
Fixes #84
Refs #61

> Note on #61: This PR **solves the Admin Dashboard impact** (time math & counters).  
> The **event remains stuck in DRAFT** issue is **not** addressed here and will be handled in a follow-up.

## Summary
This PR fixes incorrect counters on the Admin Dashboard:
- **Daily Bookings** sometimes showed 0 or wrong totals.
- **Daily Cancellations** didn’t reflect same-day cancels.

Root causes:
1) **Time window math** vs how timestamps are stored:
   - `created_at` and `cancelled_at` are `timestamp without time zone`, effectively stored as **UTC**.
   - We were comparing against **Africa/Cairo** local day using naive comparisons, which dropped rows at the edges.
2) **Status selection**: “Booked” records weren’t counted when the status was `ACCEPTED`.

## Backend changes
- **Repositories** (Event/Service/Venue):
  - Added:
    ```java
    // Bookings: created today in Cairo (converted to UTC bounds)
    long countCreatedBetweenForStatuses(LocalDateTime start, LocalDateTime end, Collection<BookingStatus> statuses);

    // Cancellations: cancelled today in Cairo (converted to UTC bounds)
    long countCancelledBetween(BookingStatus status, LocalDateTime start, LocalDateTime end);
    ```
  - `countCreatedBetweenForStatuses` checks `createdAt` and `status IN (BOOKED, ACCEPTED)`.
  - `countCancelledBetween` checks `cancelledAt` with `status = CANCELLED`.

- **StatisticsManagement**
  - `dailyBookingsBreakdown(LocalDate day)`:
    - Build Cairo local `[start, end)` **then convert to UTC** with `withZoneSameInstant(UTC)` and compare to `createdAt`.
    - Count `BOOKED` **and** `ACCEPTED`.
  - `dailyCancellationsBreakdown(LocalDate day)`:
    - Build Cairo local `[start, end)` → convert to **UTC** and compare to `cancelledAt`.

- **Cancel handlers** (Event/Service/Venue booking services)
  - Ensure:
    ```java
    booking.setStatus(BookingStatus.CANCELLED);
    booking.setCancelledAt(LocalDateTime.now(ZoneOffset.UTC)); // consistent UTC
    ```
  - Added missing imports: `LocalDateTime`, `ZoneId`, `ZoneOffset` (and `ZonedDateTime` where used).

- **AdminDashboardController**
  - Confirmed endpoints:
    - `GET /v1/admin/daily-bookings-breakdown?date=YYYY-MM-DD`
    - `GET /v1/admin/daily-cancellations-breakdown?date=YYYY-MM-DD`
  - Uses `@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)`.

## Frontend changes
- **adminApi.js**
  - New helpers using `buildApiUrl(...)` + `getAuthHeaders()`:
    - `getDailyBookingsBreakdown(dateISO)`
    - `getDailyCancellationsBreakdown(dateISO)`
- **AdminDashboard.js**
  - Import and use the new helpers in `Promise.all`.
  - Cards show correct split: `venue | services | events | total`.

## Testing / Verification
- **DB checks (Postgres)**
  - “Today in Cairo” counts are computed by first deriving the Cairo day → converting to **UTC** window → comparing to naive timestamps (`created_at`, `cancelled_at`).
  - Verified with CTE bounds query:
    ```sql
    WITH bounds AS (
      SELECT
        ((date_trunc('day', timezone('Africa/Cairo', now()))
           AT TIME ZONE 'Africa/Cairo') AT TIME ZONE 'UTC') AS start_utc,
        (((date_trunc('day', timezone('Africa/Cairo', now())) + interval '1 day')
           AT TIME ZONE 'Africa/Cairo') AT TIME ZONE 'UTC') AS end_utc
    )
    SELECT COUNT(*) FROM public.event_bookings, bounds
    WHERE created_at >= start_utc AND created_at < end_utc AND status IN ('BOOKED','ACCEPTED');
    ```
- **Manual**
  - Created a service & event booking → bookings card increments correctly.
  - Cancelled an event → cancellations card shows `{ events: +1 }` the same day.
  - Auth: Swagger authorized via **access token** (RS256), not refresh token (HS512).

## Risks / Rollback
- Timezone shifts: logic is centralized in `StatisticsManagement`. If needed, rollback by reverting to previous windows, but this PR is the correct approach for UTC-stored naive timestamps.
- If your system later stores timestamps with TZ (`timestamptz`) or in Cairo local, you’d remove the Cairo→UTC conversion.

## Checklist
- [x] Repo queries added for created/cancelled windows
- [x] Cairo→UTC window for both bookings & cancellations
- [x] Status set includes BOOKED + ACCEPTED for bookings
- [x] Cancel handlers set `cancelledAt` in UTC
- [x] Frontend calls new breakdown endpoints with auth