### PR TITLE
fix: handle venue availability for event bookin

### DIFF
--- a/front-end/src/api/venueApi.js
+++ b/front-end/src/api/venueApi.js
@@ -31,6 +31,39 @@ export async function getAllVenues() {
 }
 
 
+export async function getAvailableVenues(startDate, endDate, page = 0, size = 20) {
+  const formatDate = (date) => {
+    if (date instanceof Date) {
+      return date.toISOString().slice(0, 19);
+    }
+    if (typeof date === 'string') {
+      return new Date(date).toISOString().slice(0, 19);
+    }
+    return date;
+  };
+
+  const formattedStart = formatDate(startDate);
+  const formattedEnd = formatDate(endDate);
+
+  const url = buildApiUrl(
+    `/v1/venues/available?startDate=${encodeURIComponent(formattedStart)}&endDate=${encodeURIComponent(formattedEnd)}&page=${page}&size=${size}`
+  );
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: getAuthHeaders(true),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('API Error:', errorText);
+    throw new Error(`Failed to fetch available venues: ${response.status} - ${errorText}`);
+  }
+
+  return await response.json();
+}
+
+
 /**
  * Get all venues for the venue provider.
  * @returns {Promise<Array>} - Array of venue objects.

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ControllerConstants/VenueControllerConstants.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ControllerConstants/VenueControllerConstants.java
@@ -6,6 +6,7 @@ public final class VenueControllerConstants {
     public static final String GET_VENUE_BY_ID_URL = "/{id}";
     public static final String GET_VENUES_BY_PROVIDER_URL = "all/provider";
     public static final String GET_ALL_VENUES_URL = "/all";
+    public static final String GET_AVAILABLE_VENUES_URL = "/available";
     public static final String CREATE_VENUE_URL = "/create";
     public static final String UPDATE_VENUE_URL = "/{venueId}";
     public static final String DELETE_VENUE_URL = "/{venueId}";

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/VenueController.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/VenueController.java
@@ -7,6 +7,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import static com.example.cdr.eventsmanagementsystem.Constants.ControllerConstants.RoleConstants.*;
 
@@ -50,6 +52,16 @@ public class VenueController {
     @PreAuthorize("hasAnyRole('" + ORGANIZER_ROLE +  "','" + ADMIN_ROLE  + "')")
     public Page<VenueDTO> getAllVenues(@ParameterObject @PageableDefault() Pageable pageable) {
         return venueService.getAllVenues(pageable);
+    }
+
+    @Operation(summary = "Get available venues for a time period", description = "Retrieves all venues that are not booked during the specified time period")
+    @GetMapping(VenueControllerConstants.GET_AVAILABLE_VENUES_URL)
+    @PreAuthorize("hasAnyRole('" + ORGANIZER_ROLE + "','" + ADMIN_ROLE + "')")
+    public Page<VenueDTO> getAvailableVenues(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @ParameterObject @PageableDefault() Pageable pageable) {
+        return venueService.getAvailableVenues(startDate, endDate, pageable);
     }
 
     @Operation(summary = "Create a new venue", description = "Creates a new venue for the venue provider")

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/EventRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.cdr.eventsmanagementsystem.DTO.projections.EventTypeCount;
@@ -37,4 +38,18 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<EventTypeCount> countEventsByType();
 
     Page<Event> findByOrganizer(Organizer organizer, Pageable pageable);
+
+    @Query("""
+    SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END 
+    FROM Event e 
+    WHERE e.id IN :eventIds 
+    AND e.startTime < :endDate 
+    AND e.endTime > :startDate
+    """)
+    boolean existsEventWithTimeConflict(
+            @Param("eventIds") List<Long> eventIds,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/VenueBookingRepository.java
@@ -104,4 +104,5 @@ public interface VenueBookingRepository extends JpaRepository<VenueBooking, Long
     );
 
 
+    List<VenueBooking> findByVenueId(Long venueId);
 }


### PR DESCRIPTION
There was an error when booking an event — the same venue appeared available for another event at the same time.
This meant the system allowed two different organizers to book the same hall simultaneously.

I fixed this by adding a new endpoint that retrieves only the venues available at the time of the event.
We already handled the flow of loading in the page for Event Dashboard (see issue [#111](https://github.com/habibaaymannn/Events-Management-System/pull/111)).

## During testing,  discovered a new issue:
If there are two events and the first one is pending (venue reserved but payment not completed), the venues do not appear for other organizers.
We plan to fix this in the future, as it will be related to the payment flow.

