### PR TITLE
fix : Prevent multiple organizers from reserving the same service at …

### DIFF
--- a/front-end/src/api/serviceApi.js
+++ b/front-end/src/api/serviceApi.js
@@ -14,6 +14,41 @@ export async function getServiceById(serviceId) {
   return await response.json();
 }
 
+/*
+    * Get all available service for booking (for event organizers).
+    * Supports filtering by start and end date, with pagination.
+*/
+export async function getAvailableServices(startDate, endDate, page = 0, size = 20) {
+    console.log("Fetching available services from API...");
+    const formatDate = (date) => {
+        if (date instanceof Date) {
+            return date.toISOString().slice(0, 19);
+        }
+        if (typeof date === 'string') {
+            return new Date(date).toISOString().slice(0, 19);
+        }
+        return date;
+    };
+
+    const formattedStart = formatDate(startDate);
+    const formattedEnd = formatDate(endDate);
+
+    const url = buildApiUrl(
+        `/v1/services/available?startDate=${encodeURIComponent(formattedStart)}&endDate=${encodeURIComponent(formattedEnd)}&page=${page}&size=${size}`
+    );
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers: getAuthHeaders(true),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch available Service`);
+    }
+
+    return await response.json();
+}
+
 /**
  * Get all services.
  * BE returns a Spring Page<ServicesDTO>. We return the array (content).

--- a/front-end/src/components/event-organizer/EventOrganizerDashboard.js
+++ b/front-end/src/components/event-organizer/EventOrganizerDashboard.js
@@ -12,7 +12,7 @@ import {
   cancelVenueBooking,
   cancelServiceBooking
 } from "../../api/bookingApi";
-import { getAllVenues } from "../../api/venueApi";
+import { getAvailableServices } from "../../api/serviceApi";
 import { getAvailableVenues } from "../../api/venueApi";
 import { getAllAvailableServices } from "../../api/serviceApi";
 
@@ -116,7 +116,6 @@ const EventOrganizerDashboard = () => {
             service: serviceBookings || []
           };
         } catch (error) {
-          console.error(`Error loading bookings for event ${event.id}:`, error);
           bookingsMap[event.id] = {
             venue: [],
             service: []
@@ -329,7 +328,6 @@ const EventOrganizerDashboard = () => {
           timestamp: new Date().toISOString()
         }]);
       } catch (error) {
-        console.error("Error deleting event:", error);
         setAlerts([...alerts, {
           id: Date.now(),
           type: 'error',
@@ -363,21 +361,18 @@ const EventOrganizerDashboard = () => {
   // End code for load Venues when booking venue
 
 
-//----- Start of new code related to Service Booking -----
 const handleBookService = async (event) => {
   setSelectedEventForBooking(event);
   setShowServiceBookingModal(true);
 
   try {
-    const servicesData = await getAllAvailableServices();
+    const servicesData = await getAvailableServices(event.startTime, event.endTime);
     const services = Array.isArray(servicesData) ? servicesData : (servicesData?.content ?? []);
     setAvailableServices(services);
   } catch (error) {
     setAvailableServices([]); // Fallback to an empty list if loading fails
   }
 };
-
-//---- End of new code related to Service Booking -----
 
 
   // Handle edit venue booking
@@ -419,7 +414,7 @@ const handleBookService = async (event) => {
       setBookingToCancel(null);
       setCancellationType(null);
     } catch (error) {
-      console.error("Error confirming cancellation:", error);
+      console.error("Error confirming cancellation:");
     }
   };
 
@@ -436,7 +431,7 @@ const handleBookService = async (event) => {
         return;
       }
 
-      console.log('Cancelling venue booking with ID:', bookingId, 'Reason:', reason);
+      console.log('Cancelling venue booking' );
       await cancelVenueBooking(bookingId, reason);
 
       // Reload bookings from server to get updated status
@@ -456,7 +451,7 @@ const handleBookService = async (event) => {
 
         setSelectedVenueBooking(venueBookings || []);
       } catch (reloadError) {
-        console.error("Error reloading bookings after cancellation:", reloadError);
+        console.error("Error reloading bookings after cancellation:");
       }
 
       setAlerts(prev => [...prev, {
@@ -467,7 +462,7 @@ const handleBookService = async (event) => {
       }]);
 
     } catch (error) {
-      console.error("Error cancelling venue booking:", error);
+      console.error("Error cancelling venue booking:");
       setAlerts(prev => [...prev, {
         id: Date.now(),
         type: 'error',
@@ -489,7 +484,7 @@ const handleBookService = async (event) => {
       return;
     }
 
-    console.log('Hiding venue booking with ID:', bookingId, 'from frontend display');
+    console.log('Hiding venue booking with ID:');
 
     // Remove the booking from the frontend state (hide from display)
     setEventBookings(prev => ({
@@ -558,7 +553,7 @@ const handleBookService = async (event) => {
         ) || [];
         setSelectedServiceBookings(updatedServiceBookings);
       } catch (reloadError) {
-        console.error("Error reloading bookings after cancellation:", reloadError);
+        console.error("Error reloading bookings after cancellation:");
       }
 
       setAlerts(prev => [...prev, {
@@ -568,7 +563,7 @@ const handleBookService = async (event) => {
         timestamp: new Date().toISOString()
       }]);
     } catch (error) {
-      console.error("Error cancelling service booking:", error);
+      console.error("Error cancelling service booking:");
       setAlerts(prev => [...prev, {
         id: Date.now(),
         type: 'error',
@@ -716,7 +711,7 @@ const handleBookService = async (event) => {
         }));
       }
     } catch (error) {
-      console.error("Error booking service:", error);
+      console.error("Error booking service ");
       alert("Failed to book service. Please try again.");
     }
   };

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ControllerConstants/ServiceControllerConstants.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ControllerConstants/ServiceControllerConstants.java
@@ -7,6 +7,7 @@ public final class ServiceControllerConstants {
     public static final String GET_SERVICES_BY_PROVIDER_URL = "all/provider";
     public static final String GET_ALL_SERVICES_URL = "/all";
     public static final String CREATE_SERVICE_URL ="/create";
+    public static final String GET_AVAILABLE_SERVICE_URL = "/available";
     public static final String UPDATE_SERVICE_URL = "/{serviceId}";
     public static final String DELETE_SERVICE_URL = "/{serviceId}";
 

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ExceptionConstants.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Constants/ExceptionConstants.java
@@ -2,7 +2,8 @@ package com.example.cdr.eventsmanagementsystem.Constants;
 
 public final class ExceptionConstants {
 
-    private ExceptionConstants() {}
+    private ExceptionConstants() {
+    }
 
     public static final String EVENT_NOT_FOUND = "Event not found";
     public static final String VENUE_NOT_FOUND = "Venue not found";
@@ -11,9 +12,12 @@ public final class ExceptionConstants {
 
     public static final String YOU_CAN_ONLY_VIEW_YOUR_OWN_BOOKINGS = "You can only view your own bookings";
     public static final String YOU_CAN_ONLY_UPDATE_YOUR_OWN_BOOKINGS = "You can only update your own bookings";
-    public static final String YOU_CAN_ONLY_CANCEL_YOUR_OWN_BOOKINGS = "You can only cancel your own bookings"; 
-    
+    public static final String YOU_CAN_ONLY_CANCEL_YOUR_OWN_BOOKINGS = "You can only cancel your own bookings";
+
     public static final String UNKNOWN_ORGANIZER = "Unknown organizer";
     public static final String UNKNOWN_PROVIDER = "Unknown provider";
     public static final String UNKNOWN_ATTENDEE = "Unknown attendee";
+
+    public static final String START_DATE_MUST_BE_BEFORE_END_DATE = "Start date must be before end date";
+    public static final String START_DATE_CANNOT_BE_IN_THE_PAST = "Start date cannot be in the past";
 }

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/ServiceController.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Controller/ServiceController.java
@@ -1,6 +1,7 @@
 package com.example.cdr.eventsmanagementsystem.Controller;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.cdr.eventsmanagementsystem.Constants.ControllerConstants.RoleConstants;
@@ -17,6 +18,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -37,6 +39,18 @@ import static com.example.cdr.eventsmanagementsystem.Constants.ControllerConstan
 @Tag(name = "Service", description = "Service provider APIs for managing services")
 public class ServiceController {
     private final ServicesService servicesService;
+
+    @Operation(summary = "Get available service for a time period", description = "Retrieves all services that are not booked during the specified time period")
+    @GetMapping(ServiceControllerConstants.GET_AVAILABLE_SERVICE_URL)
+    @PreAuthorize("hasAnyRole('" + ORGANIZER_ROLE + "','" + ADMIN_ROLE + "')")
+    public Page<ServicesDTO> getAvailableService(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @ParameterObject @PageableDefault() Pageable pageable) {
+
+        System.out.println("Controller ==> Start Date: " + startDate + ", End Date: " + endDate);
+        return servicesService.getAvailableServices(startDate, endDate, pageable);
+    }
 
     @Operation(summary = "Get service by ID", description = "Retrieves service details by its ID")
     @GetMapping(ServiceControllerConstants.GET_SERVICE_BY_ID_URL)

--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Repository/ServiceBookingRepository.java
@@ -96,6 +96,6 @@ public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, 
         @Param("statuses") java.util.Collection<BookingStatus> statuses
     );
 
-
+    List<ServiceBooking> findBookingsByServiceId(Long serviceId);
 
 }


### PR DESCRIPTION
### Overview

Previously, the services endpoint returned all services, including those that were already reserved.
This caused confusion and potential conflicts when organizers attempted to make new reservations.

### What Changed

The endpoint has been changed to return only the services that are currently available.

### Benefits
- Prevents duplicate bookings