### PR TITLE
Allow larger uploads for service/venue images (10MB file / 50MB request)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,12 @@ spring:
   profiles:
     active: dev
 
+  servlet:
+    multipart:
+      max-file-size: 10MB        
+      max-request-size: 50MB     
+      enabled: true
+
   datasource:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
This PR increases the file upload size limits for service and venue images by configuring Spring Boot's multipart settings. The changes allow individual files up to 10MB and total request sizes up to 50MB.

Added multipart configuration to support larger image uploads
Increased max file size from default (1MB) to 10MB
Increased max request size from default (1MB) to 50MB

Fixes: #125 