### PR TITLE
Preserve existing images when editing a service

### DIFF
--- a/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Service/ServicesService.java
+++ b/src/main/java/com/example/cdr/eventsmanagementsystem/Service/Service/ServicesService.java
@@ -65,7 +65,7 @@ public class ServicesService {
         Services service = getService(serviceId);
         verifyAccess(service);
         serviceMapper.updateService(dto, service);
-        service.setImages(imageUtil.extractImageData(newImages));
+        service.setImages(imageUtil.mergeImages(service.getImages(), newImages));
         Services updatedVenue = serviceRepository.save(service);
         return serviceMapper.toServiceDTO(updatedVenue);
     }


### PR DESCRIPTION
Previously, editing a service removed all existing images, requiring users to re-upload them.
Now, existing images are retained, allowing users to add new images without losing the old ones.